### PR TITLE
Use arrays for authenticators and voting strategies

### DIFF
--- a/contracts/starknet/space/space.cairo
+++ b/contracts/starknet/space/space.cairo
@@ -25,11 +25,11 @@ func proposal_threshold() -> (threshold : Uint256):
 end
 
 @storage_var
-func voting_strategies(voting_strategy_contract: felt) -> (is_valid : felt):
+func voting_strategies(voting_strategy_contract : felt) -> (is_valid : felt):
 end
 
 @storage_var
-func authenticators(authenticator_address: felt) -> (is_valid : felt):
+func authenticators(authenticator_address : felt) -> (is_valid : felt):
 end
 
 @storage_var
@@ -59,7 +59,8 @@ func vote_created(proposal_id : felt, voter_address : EthAddress, vote : Vote):
 end
 
 # Throws if the caller address is not identical to the authenticator address (stored in the `authenticator` variable)
-func assert_valid_authenticator{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+func assert_valid_authenticator{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        ):
     let (caller_address) = get_caller_address()
     let (is_valid) = authenticators.read(caller_address)
 
@@ -70,7 +71,9 @@ func assert_valid_authenticator{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*
 end
 
 # Throws if the caller address is not identical to the authenticator address (stored in the `authenticator` variable)
-func assert_valid_voting_strategy{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(voting_strategy_contract: felt):
+func assert_valid_voting_strategy{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        voting_strategy_contract : felt):
     let (is_valid) = voting_strategies.read(voting_strategy_contract)
 
     # Ensure it has been initialized
@@ -79,7 +82,8 @@ func assert_valid_voting_strategy{syscall_ptr : felt*, pedersen_ptr : HashBuilti
     return ()
 end
 
-func register_voting_strategies{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(_voting_strategies_len: felt, _voting_strategies: felt*):
+func register_voting_strategies{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        _voting_strategies_len : felt, _voting_strategies : felt*):
     if _voting_strategies_len == 0:
         # List is empty
         return ()
@@ -98,7 +102,8 @@ func register_voting_strategies{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*
     end
 end
 
-func register_authenticators{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(_authenticators_len: felt, _authenticators: felt*):
+func register_authenticators{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        _authenticators_len : felt, _authenticators : felt*):
     if _authenticators_len == 0:
         # List is empty
         return ()
@@ -120,7 +125,8 @@ end
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
         _voting_delay : felt, _voting_period : felt, _proposal_threshold : Uint256,
-        _voting_strategies_len : felt, _voting_strategies: felt*, _authenticators_len : felt, _authenticators: felt*):
+        _voting_strategies_len : felt, _voting_strategies : felt*, _authenticators_len : felt,
+        _authenticators : felt*):
     # Sanity checks
     assert_nn(_voting_delay)
     assert_nn(_voting_period)
@@ -143,8 +149,8 @@ end
 
 @external
 func vote{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
-        voting_strategy_contract: felt, voter_address : EthAddress, proposal_id : felt, choice : felt, params_len : felt,
-        params : felt*) -> ():
+        voting_strategy_contract : felt, voter_address : EthAddress, proposal_id : felt,
+        choice : felt, params_len : felt, params : felt*) -> ():
     alloc_locals
 
     # Verify that the caller is the authenticator contract.
@@ -200,9 +206,9 @@ end
 # TODO: execution_hash should be of type Hash and metadata_uri of type felt* (string)
 @external
 func propose{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
-        voting_strategy_contract: felt, proposer_address : EthAddress, execution_hash : felt, metadata_uri_len : felt,
-        metadata_uri : felt*, ethereum_block_number : felt, params_len : felt, params : felt*) -> (
-        ):
+        voting_strategy_contract : felt, proposer_address : EthAddress, execution_hash : felt,
+        metadata_uri_len : felt, metadata_uri : felt*, ethereum_block_number : felt,
+        params_len : felt, params : felt*) -> ():
     alloc_locals
 
     # Verify that the caller is the authenticator contract.

--- a/contracts/starknet/space/space.cairo
+++ b/contracts/starknet/space/space.cairo
@@ -24,13 +24,12 @@ end
 func proposal_threshold() -> (threshold : Uint256):
 end
 
-# TODO: Should be Address not felt
 @storage_var
-func voting_strategy() -> (strategy_address : felt):
+func voting_strategies(voting_strategy_contract: felt) -> (is_valid : felt):
 end
 
 @storage_var
-func authenticator() -> (authenticator_address : felt):
+func authenticators(authenticator_address: felt) -> (is_valid : felt):
 end
 
 @storage_var
@@ -60,35 +59,83 @@ func vote_created(proposal_id : felt, voter_address : EthAddress, vote : Vote):
 end
 
 # Throws if the caller address is not identical to the authenticator address (stored in the `authenticator` variable)
-func authenticator_only{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+func assert_valid_authenticator{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     let (caller_address) = get_caller_address()
-    let (authenticator_address) = authenticator.read()
+    let (is_valid) = authenticators.read(caller_address)
 
     # Ensure it has been initialized
-    assert_not_zero(authenticator_address)
-    # Ensure the caller is the authenticator contract
-    assert caller_address = authenticator_address
+    assert_not_zero(is_valid)
 
     return ()
+end
+
+# Throws if the caller address is not identical to the authenticator address (stored in the `authenticator` variable)
+func assert_valid_voting_strategy{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(voting_strategy_contract: felt):
+    let (is_valid) = voting_strategies.read(voting_strategy_contract)
+
+    # Ensure it has been initialized
+    assert_not_zero(is_valid)
+
+    return ()
+end
+
+func register_voting_strategies{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(_voting_strategies_len: felt, _voting_strategies: felt*):
+    if _voting_strategies_len == 0:
+        # List is empty
+        return ()
+    else:
+        # Add voting strategy
+        voting_strategies.write(_voting_strategies[0], 1)
+
+        if _voting_strategies_len == 1:
+            # Nothing left to add, end recursion
+            return ()
+        else:
+            # Recurse
+            register_voting_strategies(_voting_strategies_len - 1, &_voting_strategies[1])
+            return ()
+        end
+    end
+end
+
+func register_authenticators{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(_authenticators_len: felt, _authenticators: felt*):
+    if _authenticators_len == 0:
+        # List is empty
+        return ()
+    else:
+        # Add voting strategy
+        authenticators.write(_authenticators[0], 1)
+
+        if _authenticators_len == 1:
+            # Nothing left to add, end recursion
+            return ()
+        else:
+            # Recurse
+            register_authenticators(_authenticators_len - 1, &_authenticators[1])
+            return ()
+        end
+    end
 end
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
         _voting_delay : felt, _voting_period : felt, _proposal_threshold : Uint256,
-        _voting_strategy : felt, _authenticator : felt):
+        _voting_strategies_len : felt, _voting_strategies: felt*, _authenticators_len : felt, _authenticators: felt*):
     # Sanity checks
     assert_nn(_voting_delay)
     assert_nn(_voting_period)
-    assert_not_zero(_voting_strategy)
-    assert_not_zero(_authenticator)
+    assert_not_zero(_voting_strategies_len)
+    assert_not_zero(_authenticators_len)
     # TODO: maybe use uint256_signed_nn to check proposal_threshold?
 
     # Initialize the storage variables
     voting_delay.write(_voting_delay)
     voting_period.write(_voting_period)
     proposal_threshold.write(_proposal_threshold)
-    voting_strategy.write(_voting_strategy)
-    authenticator.write(_authenticator)
+
+    register_voting_strategies(_voting_strategies_len, _voting_strategies)
+    register_authenticators(_authenticators_len, _authenticators)
+
     next_proposal_nonce.write(1)
 
     return ()
@@ -96,12 +143,13 @@ end
 
 @external
 func vote{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
-        voter_address : EthAddress, proposal_id : felt, choice : felt, params_len : felt,
+        voting_strategy_contract: felt, voter_address : EthAddress, proposal_id : felt, choice : felt, params_len : felt,
         params : felt*) -> ():
     alloc_locals
 
     # Verify that the caller is the authenticator contract.
-    authenticator_only()
+    assert_valid_authenticator()
+    assert_valid_voting_strategy(voting_strategy_contract)
 
     let (proposal) = proposal_registry.read(proposal_id)
     let (current_timestamp) = get_block_timestamp()
@@ -119,10 +167,8 @@ func vote{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : fe
         assert 1 = 0
     end
 
-    let (strategy_contract) = voting_strategy.read()
-
     let (user_voting_power) = IVotingStrategy.get_voting_power(
-        contract_address=strategy_contract,
+        contract_address=voting_strategy_contract,
         timestamp=current_timestamp,
         address=voter_address,
         params_len=params_len,
@@ -154,13 +200,14 @@ end
 # TODO: execution_hash should be of type Hash and metadata_uri of type felt* (string)
 @external
 func propose{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
-        proposer_address : EthAddress, execution_hash : felt, metadata_uri_len : felt,
+        voting_strategy_contract: felt, proposer_address : EthAddress, execution_hash : felt, metadata_uri_len : felt,
         metadata_uri : felt*, ethereum_block_number : felt, params_len : felt, params : felt*) -> (
         ):
     alloc_locals
 
     # Verify that the caller is the authenticator contract.
-    authenticator_only()
+    assert_valid_authenticator()
+    assert_valid_voting_strategy(voting_strategy_contract)
 
     let (current_timestamp) = get_block_timestamp()
     let (delay) = voting_delay.read()
@@ -171,9 +218,8 @@ func propose{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr :
     let end_timestamp = start_timestamp + duration
 
     # Get the voting power of the proposer
-    let (strategy_contract) = voting_strategy.read()
     let (voting_power) = IVotingStrategy.get_voting_power(
-        contract_address=strategy_contract,
+        contract_address=voting_strategy_contract,
         timestamp=start_timestamp,
         address=proposer_address,
         params_len=params_len,

--- a/test/starknet/vanilla_space.ts
+++ b/test/starknet/vanilla_space.ts
@@ -111,7 +111,13 @@ describe('Space testing', () => {
       await vanillaAuthenticator.invoke(EXECUTE_METHOD, {
         to: space_contract,
         function_selector: BigInt(getSelectorFromName(VOTE_METHOD)),
-        calldata: [BigInt(vanillaVotingStrategy.address), voter_address, proposal_id, FOR, BigInt(params.length)],
+        calldata: [
+          BigInt(vanillaVotingStrategy.address),
+          voter_address,
+          proposal_id,
+          FOR,
+          BigInt(params.length),
+        ],
       });
 
       console.log('Getting proposal info...');

--- a/test/starknet/vanilla_space.ts
+++ b/test/starknet/vanilla_space.ts
@@ -38,8 +38,8 @@ async function setup() {
     _voting_delay: VOTING_DELAY,
     _voting_period: VOTING_PERIOD,
     _proposal_threshold: PROPOSAL_THRESHOLD,
-    _voting_strategy: voting_strategy,
-    _authenticator: authenticator,
+    _voting_strategies: [voting_strategy],
+    _authenticators: [authenticator],
   })) as StarknetContract;
 
   return {
@@ -64,6 +64,7 @@ describe('Space testing', () => {
     const params: Array<bigint> = [];
     const eth_block_number = BigInt(1337);
     const calldata = [
+      BigInt(vanillaVotingStrategy.address),
       proposer_address,
       execution_hash,
       BigInt(metadata_uri.length),
@@ -110,7 +111,7 @@ describe('Space testing', () => {
       await vanillaAuthenticator.invoke(EXECUTE_METHOD, {
         to: space_contract,
         function_selector: BigInt(getSelectorFromName(VOTE_METHOD)),
-        calldata: [voter_address, proposal_id, FOR, BigInt(params.length)],
+        calldata: [BigInt(vanillaVotingStrategy.address), voter_address, proposal_id, FOR, BigInt(params.length)],
       });
 
       console.log('Getting proposal info...');


### PR DESCRIPTION
Instead of using a single authenticator and a single voting strategy, spaces can now pass in arrays of authenticators and voting strategies to the space constructor. 