### PR TITLE
Add whitelist strategy

### DIFF
--- a/contracts/starknet/voting_strategies/whitelist.cairo
+++ b/contracts/starknet/voting_strategies/whitelist.cairo
@@ -19,12 +19,12 @@ func register_whitelist{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_
     else:
         let address = EthAddress(_whitelist[0])
         # Add it to the whitelist
-        whitelist.write(address, 1)
+        whitelist.write(address, _whitelist[1])
 
         # Emit event
         whitelisted.emit(address)
 
-        register_whitelist(_whitelist_len - 1, &_whitelist[1])
+        register_whitelist(_whitelist_len - 2, &_whitelist[2])
         return ()
     end
 end

--- a/contracts/starknet/voting_strategies/whitelist.cairo
+++ b/contracts/starknet/voting_strategies/whitelist.cairo
@@ -43,5 +43,7 @@ func get_voting_power{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_ch
         voting_power : Uint256):
     let (power) = whitelist.read(address)
 
+    # `power` will be set to 1 if the address is whitelisted, and 0 otherwise
+    # so using it as the `low` value for the `Uint256` is safe.
     return (Uint256(power, 0))
 end

--- a/contracts/starknet/voting_strategies/whitelist.cairo
+++ b/contracts/starknet/voting_strategies/whitelist.cairo
@@ -1,0 +1,47 @@
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from contracts.starknet.lib.eth_address import EthAddress
+
+@storage_var
+func whitelist(address : EthAddress) -> (is_valid : felt):
+end
+
+@event
+func whitelisted(address : EthAddress):
+end
+
+func register_whitelist{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
+        _whitelist_len : felt, _whitelist : felt*):
+    if _whitelist_len == 0:
+        return ()
+    else:
+        let address = EthAddress(_whitelist[0])
+        # Add it to the whitelist
+        whitelist.write(address, 1)
+
+        # Emit event
+        whitelisted.emit(address)
+
+        register_whitelist(_whitelist_len - 1, &_whitelist[1])
+        return ()
+    end
+end
+
+@constructor
+func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
+        _whitelist_len : felt, _whitelist : felt*):
+    register_whitelist(_whitelist_len, _whitelist)
+    return ()
+end
+
+# Returns a voting power of 1 if the user is in the whitelist
+@view
+func get_voting_power{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
+        timestamp : felt, address : EthAddress, params_len : felt, params : felt*) -> (
+        voting_power : Uint256):
+    let (power) = whitelist.read(address)
+
+    return (Uint256(power, 0))
+end

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -27,7 +27,7 @@ echo "Deploying auth contract..."
 AUTH=$(hardhat starknet-deploy ${NETWORK_OPTION} starknet-artifacts/contracts/starknet/authenticator/authenticator.cairo/authenticator.json | grep 'Contract address' | tail -c 67)
 echo "✅ Auth: ${AUTH}"
 echo "Deploying strategy contract"
-STRATEGY=$(hardhat starknet-deploy ${NETWORK_OPTION} starknet-artifacts/contracts/starknet/strategies/vanilla_voting_strategy.cairo/vanilla_voting_strategy.json | grep 'Contract address' | tail -c 67)
+STRATEGY=$(hardhat starknet-deploy ${NETWORK_OPTION} starknet-artifacts/contracts/starknet/voting_strategies/vanilla_voting_strategy.cairo/vanilla_voting_strategy.json | grep 'Contract address' | tail -c 67)
 echo "✅ Strategy: ${STRATEGY}"
 echo "Deploying space contract"
 SPACE=$(hardhat starknet-deploy ${NETWORK_OPTION} --inputs "${VOTING_DELAY} ${VOTING_DURATION} ${THRESHOLD} 0 ${STRATEGY} ${AUTH}" starknet-artifacts/contracts/starknet/space/space.cairo/space.json | grep 'Contract address' | tail -c 67)

--- a/test/starknet/whitelist_strategy.ts
+++ b/test/starknet/whitelist_strategy.ts
@@ -160,4 +160,4 @@ describe('Whitelist testing', () => {
     const expected = SplitUint256.fromUint(BigInt(0));
     expect(vp).to.deep.equal(expected);
   });
-});
+}).timeout(600000);

--- a/test/starknet/whitelist_strategy.ts
+++ b/test/starknet/whitelist_strategy.ts
@@ -18,11 +18,11 @@ describe('Whitelist testing', () => {
   const ADDRR_3 = BigInt('33333');
   const ADDRR_4 = BigInt('44444');
 
-  const VITALIK_POWER = BigInt('1000');
-  const ADDRR_1_POWER = BigInt('1');
-  const ADDRR_2_POWER = BigInt('2');
-  const ADDRR_3_POWER = BigInt('3');
-  const ADDRR_4_POWER = BigInt('4');
+  const VITALIK_POWER = SplitUint256.fromUint(BigInt('1000'));
+  const ADDRR_1_POWER = SplitUint256.fromUint(BigInt('1'));
+  const ADDRR_2_POWER = SplitUint256.fromUint(BigInt('2'));
+  const ADDRR_3_POWER = SplitUint256.fromUint(BigInt('3'));
+  const ADDRR_4_POWER = SplitUint256.fromUint(BigInt('4'));
 
   before(async function () {
     this.timeout(800000);
@@ -31,29 +31,36 @@ describe('Whitelist testing', () => {
       './contracts/starknet/voting_strategies/whitelist.cairo'
     );
     whitelistStrat = await whitelistFactory.deploy({
-      _whitelist: [VITALIK_ADDRESS, VITALIK_POWER],
+      _whitelist: [VITALIK_ADDRESS, VITALIK_POWER.low, VITALIK_POWER.high],
     });
     emptyStrat = await whitelistFactory.deploy({ _whitelist: [] });
     repeatStrat = await whitelistFactory.deploy({
       _whitelist: [
         VITALIK_ADDRESS,
-        VITALIK_POWER,
+        VITALIK_POWER.low,
+        VITALIK_POWER.high,
         VITALIK_ADDRESS,
-        VITALIK_POWER,
+        VITALIK_POWER.low,
+        VITALIK_POWER.high,
         ADDRR_1,
-        ADDRR_1_POWER,
+        ADDRR_1_POWER.low,
+        ADDRR_1_POWER.high,
       ],
     });
     bigStrat = await whitelistFactory.deploy({
       _whitelist: [
         ADDRR_1,
-        ADDRR_1_POWER,
+        ADDRR_1_POWER.low,
+        ADDRR_1_POWER.high,
         ADDRR_2,
-        ADDRR_2_POWER,
+        ADDRR_2_POWER.low,
+        ADDRR_2_POWER.high,
         ADDRR_3,
-        ADDRR_3_POWER,
+        ADDRR_3_POWER.low,
+        ADDRR_3_POWER.high,
         ADDRR_4,
-        ADDRR_4_POWER,
+        ADDRR_4_POWER.low,
+        ADDRR_4_POWER.high,
       ],
     });
   });
@@ -80,7 +87,7 @@ describe('Whitelist testing', () => {
     });
 
     const vp = SplitUint256.fromObj(voting_power);
-    const expected = SplitUint256.fromUint(VITALIK_POWER);
+    const expected = VITALIK_POWER;
     expect(vp).to.deep.equal(expected);
   });
 
@@ -104,7 +111,7 @@ describe('Whitelist testing', () => {
     });
 
     const vp = SplitUint256.fromObj(voting_power);
-    const expected = SplitUint256.fromUint(VITALIK_POWER);
+    const expected = VITALIK_POWER;
     expect(vp).to.deep.equal(expected);
   });
 
@@ -116,7 +123,7 @@ describe('Whitelist testing', () => {
     });
 
     const vp = SplitUint256.fromObj(voting_power);
-    const expected = SplitUint256.fromUint(ADDRR_1_POWER);
+    const expected = ADDRR_1_POWER;
     expect(vp).to.deep.equal(expected);
   });
 
@@ -146,7 +153,7 @@ describe('Whitelist testing', () => {
     const expected_power = [ADDRR_1_POWER, ADDRR_2_POWER, ADDRR_3_POWER, ADDRR_4_POWER];
     results.forEach(function ({ voting_power }, index) {
       const vp = SplitUint256.fromObj(voting_power);
-      const expected = SplitUint256.fromUint(expected_power[index]);
+      const expected = expected_power[index];
       expect(vp).to.deep.equal(expected);
     });
   });

--- a/test/starknet/whitelist_strategy.ts
+++ b/test/starknet/whitelist_strategy.ts
@@ -1,0 +1,96 @@
+import { stark } from 'starknet';
+import { SplitUint256, FOR } from './shared/types';
+import { strToShortStringArr } from '@snapshot-labs/sx';
+import { expect } from 'chai';
+import { starknet } from 'hardhat';
+import {
+  VITALIK_ADDRESS,
+} from './shared/setup';
+import { StarknetContract } from 'hardhat/types';
+
+const { getSelectorFromName } = stark;
+
+describe('Whitelist testing', () => {
+  let whitelistStrat: StarknetContract;
+  let emptyStrat: StarknetContract;
+  let repeatStrat: StarknetContract;
+  let bigStrat: StarknetContract;
+  const ADDRR_1 = BigInt("11111");
+  const ADDRR_2 = BigInt("22222");
+  const ADDRR_3 = BigInt("33333");
+  const ADDRR_4 = BigInt("44444");
+
+  before(async function () {
+    const whitelistFactory = await starknet.getContractFactory(
+      './contracts/starknet/strategies/whitelist.cairo'
+    );
+    whitelistStrat = await whitelistFactory.deploy({_whitelist: [VITALIK_ADDRESS]});
+    emptyStrat = await whitelistFactory.deploy({_whitelist: []});
+    repeatStrat = await whitelistFactory.deploy({_whitelist: [VITALIK_ADDRESS, VITALIK_ADDRESS, ADDRR_1]});
+    bigStrat = await whitelistFactory.deploy({_whitelist: [ADDRR_1, ADDRR_2, ADDRR_3, ADDRR_4]});
+  });
+
+  it('returns 0 for non-whitelisted addresses', async () => {
+      const random_address = BigInt(0x12345);
+      let {voting_power} = await whitelistStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: random_address}, params: []});
+
+      let vp = SplitUint256.fromObj(voting_power);
+      let expected = SplitUint256.fromUint(BigInt(0));
+      expect(vp).to.deep.equal(expected);
+  });
+
+  it('returns 1 for whitelisted addresses', async () => {
+      const random_address = BigInt(0x12345);
+      let {voting_power} = await whitelistStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: VITALIK_ADDRESS}, params: []});
+
+      let vp = SplitUint256.fromObj(voting_power);
+      let expected = SplitUint256.fromUint(BigInt(1));
+      expect(vp).to.deep.equal(expected);
+  });
+
+  it('returns 0 for an empty whitelist', async () => {
+      let {voting_power} = await emptyStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: VITALIK_ADDRESS}, params: []});
+
+      let vp = SplitUint256.fromObj(voting_power);
+      let expected = SplitUint256.fromUint(BigInt(0));
+      expect(vp).to.deep.equal(expected);
+  });
+
+  it('returns 1 even if address is repeated', async () => {
+      let {voting_power} = await repeatStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: VITALIK_ADDRESS}, params: []});
+
+      let vp = SplitUint256.fromObj(voting_power);
+      let expected = SplitUint256.fromUint(BigInt(1));
+      expect(vp).to.deep.equal(expected);
+  });
+
+  it('returns 1 if address is NOT repeated', async () => {
+      let {voting_power} = await bigStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: ADDRR_1}, params: []});
+
+      let vp = SplitUint256.fromObj(voting_power);
+      let expected = SplitUint256.fromUint(BigInt(1));
+      expect(vp).to.deep.equal(expected);
+  });
+
+  it('returns 1 even for everyone in the list', async () => {
+      let voting_power1 = await bigStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: ADDRR_1}, params: []});
+      let voting_power2 = await bigStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: ADDRR_2}, params: []});
+      let voting_power3 = await bigStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: ADDRR_3}, params: []});
+      let voting_power4 = await bigStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: ADDRR_4}, params: []});
+
+      const results = [voting_power1, voting_power2, voting_power3, voting_power4];
+      const expected = SplitUint256.fromUint(BigInt(1));
+      for (const {voting_power} of results) {
+        let vp = SplitUint256.fromObj(voting_power);
+        expect(vp).to.deep.equal(expected);
+      }
+  });
+
+  it('returns 0 if address is NOT in the big list', async () => {
+      let {voting_power} = await bigStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: VITALIK_ADDRESS}, params: []});
+
+      let vp = SplitUint256.fromObj(voting_power);
+      let expected = SplitUint256.fromUint(BigInt(0));
+      expect(vp).to.deep.equal(expected);
+  });
+});

--- a/test/starknet/whitelist_strategy.ts
+++ b/test/starknet/whitelist_strategy.ts
@@ -25,6 +25,8 @@ describe('Whitelist testing', () => {
   const ADDRR_4_POWER = BigInt('4');
 
   before(async function () {
+    this.timeout(800000);
+
     const whitelistFactory = await starknet.getContractFactory(
       './contracts/starknet/voting_strategies/whitelist.cairo'
     );

--- a/test/starknet/whitelist_strategy.ts
+++ b/test/starknet/whitelist_strategy.ts
@@ -26,7 +26,7 @@ describe('Whitelist testing', () => {
 
   before(async function () {
     const whitelistFactory = await starknet.getContractFactory(
-      './contracts/starknet/strategies/whitelist.cairo'
+      './contracts/starknet/voting_strategies/whitelist.cairo'
     );
     whitelistStrat = await whitelistFactory.deploy({
       _whitelist: [VITALIK_ADDRESS, VITALIK_POWER],

--- a/test/starknet/whitelist_strategy.ts
+++ b/test/starknet/whitelist_strategy.ts
@@ -18,16 +18,42 @@ describe('Whitelist testing', () => {
   const ADDRR_3 = BigInt('33333');
   const ADDRR_4 = BigInt('44444');
 
+  const VITALIK_POWER = BigInt('1000');
+  const ADDRR_1_POWER = BigInt('1');
+  const ADDRR_2_POWER = BigInt('2');
+  const ADDRR_3_POWER = BigInt('3');
+  const ADDRR_4_POWER = BigInt('4');
+
   before(async function () {
     const whitelistFactory = await starknet.getContractFactory(
       './contracts/starknet/strategies/whitelist.cairo'
     );
-    whitelistStrat = await whitelistFactory.deploy({ _whitelist: [VITALIK_ADDRESS] });
+    whitelistStrat = await whitelistFactory.deploy({
+      _whitelist: [VITALIK_ADDRESS, VITALIK_POWER],
+    });
     emptyStrat = await whitelistFactory.deploy({ _whitelist: [] });
     repeatStrat = await whitelistFactory.deploy({
-      _whitelist: [VITALIK_ADDRESS, VITALIK_ADDRESS, ADDRR_1],
+      _whitelist: [
+        VITALIK_ADDRESS,
+        VITALIK_POWER,
+        VITALIK_ADDRESS,
+        VITALIK_POWER,
+        ADDRR_1,
+        ADDRR_1_POWER,
+      ],
     });
-    bigStrat = await whitelistFactory.deploy({ _whitelist: [ADDRR_1, ADDRR_2, ADDRR_3, ADDRR_4] });
+    bigStrat = await whitelistFactory.deploy({
+      _whitelist: [
+        ADDRR_1,
+        ADDRR_1_POWER,
+        ADDRR_2,
+        ADDRR_2_POWER,
+        ADDRR_3,
+        ADDRR_3_POWER,
+        ADDRR_4,
+        ADDRR_4_POWER,
+      ],
+    });
   });
 
   it('returns 0 for non-whitelisted addresses', async () => {
@@ -43,7 +69,7 @@ describe('Whitelist testing', () => {
     expect(vp).to.deep.equal(expected);
   });
 
-  it('returns 1 for whitelisted addresses', async () => {
+  it('returns voting power for whitelisted addresses', async () => {
     const random_address = BigInt(0x12345);
     const { voting_power } = await whitelistStrat.call('get_voting_power', {
       timestamp: BigInt(0),
@@ -52,7 +78,7 @@ describe('Whitelist testing', () => {
     });
 
     const vp = SplitUint256.fromObj(voting_power);
-    const expected = SplitUint256.fromUint(BigInt(1));
+    const expected = SplitUint256.fromUint(VITALIK_POWER);
     expect(vp).to.deep.equal(expected);
   });
 
@@ -76,7 +102,7 @@ describe('Whitelist testing', () => {
     });
 
     const vp = SplitUint256.fromObj(voting_power);
-    const expected = SplitUint256.fromUint(BigInt(1));
+    const expected = SplitUint256.fromUint(VITALIK_POWER);
     expect(vp).to.deep.equal(expected);
   });
 
@@ -88,7 +114,7 @@ describe('Whitelist testing', () => {
     });
 
     const vp = SplitUint256.fromObj(voting_power);
-    const expected = SplitUint256.fromUint(BigInt(1));
+    const expected = SplitUint256.fromUint(ADDRR_1_POWER);
     expect(vp).to.deep.equal(expected);
   });
 
@@ -115,11 +141,12 @@ describe('Whitelist testing', () => {
     });
 
     const results = [voting_power1, voting_power2, voting_power3, voting_power4];
-    const expected = SplitUint256.fromUint(BigInt(1));
-    for (const { voting_power } of results) {
+    const expected_power = [ADDRR_1_POWER, ADDRR_2_POWER, ADDRR_3_POWER, ADDRR_4_POWER];
+    results.forEach(function ({ voting_power }, index) {
       const vp = SplitUint256.fromObj(voting_power);
+      const expected = SplitUint256.fromUint(expected_power[index]);
       expect(vp).to.deep.equal(expected);
-    }
+    });
   });
 
   it('returns 0 if address is NOT in the big list', async () => {

--- a/test/starknet/whitelist_strategy.ts
+++ b/test/starknet/whitelist_strategy.ts
@@ -3,9 +3,7 @@ import { SplitUint256, FOR } from './shared/types';
 import { strToShortStringArr } from '@snapshot-labs/sx';
 import { expect } from 'chai';
 import { starknet } from 'hardhat';
-import {
-  VITALIK_ADDRESS,
-} from './shared/setup';
+import { VITALIK_ADDRESS } from './shared/setup';
 import { StarknetContract } from 'hardhat/types';
 
 const { getSelectorFromName } = stark;
@@ -15,82 +13,124 @@ describe('Whitelist testing', () => {
   let emptyStrat: StarknetContract;
   let repeatStrat: StarknetContract;
   let bigStrat: StarknetContract;
-  const ADDRR_1 = BigInt("11111");
-  const ADDRR_2 = BigInt("22222");
-  const ADDRR_3 = BigInt("33333");
-  const ADDRR_4 = BigInt("44444");
+  const ADDRR_1 = BigInt('11111');
+  const ADDRR_2 = BigInt('22222');
+  const ADDRR_3 = BigInt('33333');
+  const ADDRR_4 = BigInt('44444');
 
   before(async function () {
     const whitelistFactory = await starknet.getContractFactory(
       './contracts/starknet/strategies/whitelist.cairo'
     );
-    whitelistStrat = await whitelistFactory.deploy({_whitelist: [VITALIK_ADDRESS]});
-    emptyStrat = await whitelistFactory.deploy({_whitelist: []});
-    repeatStrat = await whitelistFactory.deploy({_whitelist: [VITALIK_ADDRESS, VITALIK_ADDRESS, ADDRR_1]});
-    bigStrat = await whitelistFactory.deploy({_whitelist: [ADDRR_1, ADDRR_2, ADDRR_3, ADDRR_4]});
+    whitelistStrat = await whitelistFactory.deploy({ _whitelist: [VITALIK_ADDRESS] });
+    emptyStrat = await whitelistFactory.deploy({ _whitelist: [] });
+    repeatStrat = await whitelistFactory.deploy({
+      _whitelist: [VITALIK_ADDRESS, VITALIK_ADDRESS, ADDRR_1],
+    });
+    bigStrat = await whitelistFactory.deploy({ _whitelist: [ADDRR_1, ADDRR_2, ADDRR_3, ADDRR_4] });
   });
 
   it('returns 0 for non-whitelisted addresses', async () => {
-      const random_address = BigInt(0x12345);
-      let {voting_power} = await whitelistStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: random_address}, params: []});
+    const random_address = BigInt(0x12345);
+    const { voting_power } = await whitelistStrat.call('get_voting_power', {
+      timestamp: BigInt(0),
+      address: { value: random_address },
+      params: [],
+    });
 
-      let vp = SplitUint256.fromObj(voting_power);
-      let expected = SplitUint256.fromUint(BigInt(0));
-      expect(vp).to.deep.equal(expected);
+    const vp = SplitUint256.fromObj(voting_power);
+    const expected = SplitUint256.fromUint(BigInt(0));
+    expect(vp).to.deep.equal(expected);
   });
 
   it('returns 1 for whitelisted addresses', async () => {
-      const random_address = BigInt(0x12345);
-      let {voting_power} = await whitelistStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: VITALIK_ADDRESS}, params: []});
+    const random_address = BigInt(0x12345);
+    const { voting_power } = await whitelistStrat.call('get_voting_power', {
+      timestamp: BigInt(0),
+      address: { value: VITALIK_ADDRESS },
+      params: [],
+    });
 
-      let vp = SplitUint256.fromObj(voting_power);
-      let expected = SplitUint256.fromUint(BigInt(1));
-      expect(vp).to.deep.equal(expected);
+    const vp = SplitUint256.fromObj(voting_power);
+    const expected = SplitUint256.fromUint(BigInt(1));
+    expect(vp).to.deep.equal(expected);
   });
 
   it('returns 0 for an empty whitelist', async () => {
-      let {voting_power} = await emptyStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: VITALIK_ADDRESS}, params: []});
+    const { voting_power } = await emptyStrat.call('get_voting_power', {
+      timestamp: BigInt(0),
+      address: { value: VITALIK_ADDRESS },
+      params: [],
+    });
 
-      let vp = SplitUint256.fromObj(voting_power);
-      let expected = SplitUint256.fromUint(BigInt(0));
-      expect(vp).to.deep.equal(expected);
+    const vp = SplitUint256.fromObj(voting_power);
+    const expected = SplitUint256.fromUint(BigInt(0));
+    expect(vp).to.deep.equal(expected);
   });
 
   it('returns 1 even if address is repeated', async () => {
-      let {voting_power} = await repeatStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: VITALIK_ADDRESS}, params: []});
+    const { voting_power } = await repeatStrat.call('get_voting_power', {
+      timestamp: BigInt(0),
+      address: { value: VITALIK_ADDRESS },
+      params: [],
+    });
 
-      let vp = SplitUint256.fromObj(voting_power);
-      let expected = SplitUint256.fromUint(BigInt(1));
-      expect(vp).to.deep.equal(expected);
+    const vp = SplitUint256.fromObj(voting_power);
+    const expected = SplitUint256.fromUint(BigInt(1));
+    expect(vp).to.deep.equal(expected);
   });
 
   it('returns 1 if address is NOT repeated', async () => {
-      let {voting_power} = await bigStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: ADDRR_1}, params: []});
+    const { voting_power } = await bigStrat.call('get_voting_power', {
+      timestamp: BigInt(0),
+      address: { value: ADDRR_1 },
+      params: [],
+    });
 
-      let vp = SplitUint256.fromObj(voting_power);
-      let expected = SplitUint256.fromUint(BigInt(1));
-      expect(vp).to.deep.equal(expected);
+    const vp = SplitUint256.fromObj(voting_power);
+    const expected = SplitUint256.fromUint(BigInt(1));
+    expect(vp).to.deep.equal(expected);
   });
 
   it('returns 1 even for everyone in the list', async () => {
-      let voting_power1 = await bigStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: ADDRR_1}, params: []});
-      let voting_power2 = await bigStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: ADDRR_2}, params: []});
-      let voting_power3 = await bigStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: ADDRR_3}, params: []});
-      let voting_power4 = await bigStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: ADDRR_4}, params: []});
+    const voting_power1 = await bigStrat.call('get_voting_power', {
+      timestamp: BigInt(0),
+      address: { value: ADDRR_1 },
+      params: [],
+    });
+    const voting_power2 = await bigStrat.call('get_voting_power', {
+      timestamp: BigInt(0),
+      address: { value: ADDRR_2 },
+      params: [],
+    });
+    const voting_power3 = await bigStrat.call('get_voting_power', {
+      timestamp: BigInt(0),
+      address: { value: ADDRR_3 },
+      params: [],
+    });
+    const voting_power4 = await bigStrat.call('get_voting_power', {
+      timestamp: BigInt(0),
+      address: { value: ADDRR_4 },
+      params: [],
+    });
 
-      const results = [voting_power1, voting_power2, voting_power3, voting_power4];
-      const expected = SplitUint256.fromUint(BigInt(1));
-      for (const {voting_power} of results) {
-        let vp = SplitUint256.fromObj(voting_power);
-        expect(vp).to.deep.equal(expected);
-      }
+    const results = [voting_power1, voting_power2, voting_power3, voting_power4];
+    const expected = SplitUint256.fromUint(BigInt(1));
+    for (const { voting_power } of results) {
+      const vp = SplitUint256.fromObj(voting_power);
+      expect(vp).to.deep.equal(expected);
+    }
   });
 
   it('returns 0 if address is NOT in the big list', async () => {
-      let {voting_power} = await bigStrat.call("get_voting_power", {timestamp: BigInt(0), address: {value: VITALIK_ADDRESS}, params: []});
+    const { voting_power } = await bigStrat.call('get_voting_power', {
+      timestamp: BigInt(0),
+      address: { value: VITALIK_ADDRESS },
+      params: [],
+    });
 
-      let vp = SplitUint256.fromObj(voting_power);
-      let expected = SplitUint256.fromUint(BigInt(0));
-      expect(vp).to.deep.equal(expected);
+    const vp = SplitUint256.fromObj(voting_power);
+    const expected = SplitUint256.fromUint(BigInt(0));
+    expect(vp).to.deep.equal(expected);
   });
 });


### PR DESCRIPTION
- Adds a simple whitelist strategy. The smart contract has no owner: whitelisted addresses are declared in the constructor. If we wish to add / remove addresses, just create a new smart contract (as this is a voting strategy and won't hold any funds, I think it's safe to to so).
- As mentioned in #99 , we will need to transition to something else than `EthAddress` as the type for the `get_voting_power` interface because we might also have starkkeys, or solana keys, or bitcoin keys etc...

Closes #92 