### PR TITLE
Add starknet auth

### DIFF
--- a/contracts/starknet/authenticators/eth_tx.cairo
+++ b/contracts/starknet/authenticators/eth_tx.cairo
@@ -43,7 +43,14 @@ end
 
 @external
 func execute{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
-    target : felt, function_selector : felt, calldata_len : felt, calldata : felt*
+    target : felt,
+    function_selector : felt,
+    calldata_len : felt,
+    calldata : felt*,
+    signer_len : felt,
+    signer : felt*,
+    signature_len : felt,
+    signature : felt*,
 ):
     alloc_locals
     # Cast arguments to single array

--- a/contracts/starknet/authenticators/starknet.cairo
+++ b/contracts/starknet/authenticators/starknet.cairo
@@ -4,7 +4,7 @@ from contracts.starknet.lib.hash_array import hash_array
 from starkware.cairo.common.signature import verify_ecdsa_signature
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 
-# Starknet key authenticator
+# Starknet key authenticator.
 @external
 func execute{
     syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*, ecdsa_ptr : SignatureBuiltin*

--- a/contracts/starknet/authenticators/starknet.cairo
+++ b/contracts/starknet/authenticators/starknet.cairo
@@ -1,0 +1,42 @@
+%lang starknet
+from starkware.starknet.common.syscalls import call_contract
+from contracts.starknet.lib.hash_array import hash_array
+from starkware.cairo.common.signature import verify_ecdsa_signature
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+
+# Forwards `data` to `target` without verifying anything.
+@external
+func execute{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*, ecdsa_ptr : SignatureBuiltin*
+}(
+    target : felt,
+    function_selector : felt,
+    calldata_len : felt,
+    calldata : felt*,
+    signer_len : felt,
+    signer : felt*,
+    signature_len : felt,
+    signature : felt*,
+) -> ():
+    assert signature_len = 2
+    assert signer_len = 1
+
+    let (message_hash) = hash_array(calldata_len, calldata)
+
+    verify_ecdsa_signature(
+        message=message_hash,
+        public_key=signer[0],
+        signature_r=signature[0],
+        signature_s=signature[1],
+    )
+
+    # Call the contract
+    call_contract(
+        contract_address=target,
+        function_selector=function_selector,
+        calldata_size=calldata_len,
+        calldata=calldata,
+    )
+
+    return ()
+end

--- a/contracts/starknet/authenticators/starknet.cairo
+++ b/contracts/starknet/authenticators/starknet.cairo
@@ -4,7 +4,7 @@ from contracts.starknet.lib.hash_array import hash_array
 from starkware.cairo.common.signature import verify_ecdsa_signature
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 
-# Forwards `data` to `target` without verifying anything.
+# Starknet key authenticator
 @external
 func execute{
     syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*, ecdsa_ptr : SignatureBuiltin*

--- a/contracts/starknet/authenticators/vanilla.cairo
+++ b/contracts/starknet/authenticators/vanilla.cairo
@@ -4,7 +4,14 @@ from starkware.starknet.common.syscalls import call_contract
 # Forwards `data` to `target` without verifying anything.
 @external
 func execute{syscall_ptr : felt*, range_check_ptr}(
-    target : felt, function_selector : felt, calldata_len : felt, calldata : felt*
+    target : felt,
+    function_selector : felt,
+    calldata_len : felt,
+    calldata : felt*,
+    signer_len : felt,
+    signer : felt*,
+    signature_len : felt,
+    signature : felt*,
 ) -> ():
     # TODO: Actually verify the signature
 

--- a/contracts/starknet/interfaces/i_authenticator.cairo
+++ b/contracts/starknet/interfaces/i_authenticator.cairo
@@ -2,6 +2,15 @@
 
 @contract_interface
 namespace i_authenticator:
-    func execute(target : felt, function_selector : felt, calldata_len : felt, calldata : felt*):
+    func execute(
+        target : felt,
+        function_selector : felt,
+        calldata_len : felt,
+        calldata : felt*,
+        signer_len : felt,
+        signer : felt*,
+        signature_len : felt,
+        signature : felt*,
+    ):
     end
 end

--- a/test/crosschain/eth_tx_auth.ts
+++ b/test/crosschain/eth_tx_auth.ts
@@ -99,6 +99,8 @@ describe('L1 interaction with Snapshot X', function () {
       target: target,
       function_selector: propose_selector,
       calldata: propose_calldata,
+      signer: [],
+      signature: [],
     });
   });
 
@@ -114,6 +116,8 @@ describe('L1 interaction with Snapshot X', function () {
       target: target,
       function_selector: propose_selector,
       calldata: propose_calldata,
+      signer: [],
+      signature: [],
     });
     // Second execute should fail
     try {
@@ -121,6 +125,8 @@ describe('L1 interaction with Snapshot X', function () {
         target: target,
         function_selector: propose_selector,
         calldata: propose_calldata,
+        signer: [],
+        signature: [],
       });
     } catch (err: any) {
       expect(err.message).to.contain('Hash not yet committed or already executed');
@@ -140,6 +146,8 @@ describe('L1 interaction with Snapshot X', function () {
         target: target,
         function_selector: propose_selector,
         calldata: propose_calldata,
+        signer: [],
+        signature: [],
       });
     } catch (err: any) {
       expect(err.message).to.contain('Hash not yet committed or already executed');
@@ -159,6 +167,8 @@ describe('L1 interaction with Snapshot X', function () {
         target: target,
         function_selector: propose_selector,
         calldata: propose_calldata,
+        signer: [],
+        signature: [],
       });
     } catch (err: any) {
       expect(err.message).to.contain('Commit made by invalid L1 address');

--- a/test/crosschain/zodiac.ts
+++ b/test/crosschain/zodiac.ts
@@ -127,6 +127,8 @@ describe('Create proposal, cast vote, and send execution to l1', function () {
       target: BigInt(spaceContract.address),
       function_selector: BigInt(getSelectorFromName(PROPOSAL_METHOD)),
       calldata,
+      signer: [],
+      signature: [],
     });
 
     // -- Casts a vote FOR --
@@ -137,6 +139,8 @@ describe('Create proposal, cast vote, and send execution to l1', function () {
         target: BigInt(spaceContract.address),
         function_selector: BigInt(getSelectorFromName(VOTE_METHOD)),
         calldata: [voter_address, proposal_id, FOR, BigInt(votingParams.length), ...votingParams],
+        signer: [],
+        signature: [],
       });
 
       const { proposal_info } = await spaceContract.call('get_proposal_info', {

--- a/test/starknet/executor_whitelist.ts
+++ b/test/starknet/executor_whitelist.ts
@@ -79,6 +79,8 @@ describe('Whitelist testing', () => {
         target: spaceContract,
         function_selector: BigInt(getSelectorFromName(PROPOSAL_METHOD)),
         calldata,
+        signer: [],
+        signature: [],
       });
     }
   });
@@ -96,6 +98,8 @@ describe('Whitelist testing', () => {
         target: spaceContract,
         function_selector: BigInt(getSelectorFromName(PROPOSAL_METHOD)),
         calldata,
+        signer: [],
+        signature: [],
       });
     } catch (err: any) {
       expect(err.message).to.contain('Invalid executor');
@@ -111,6 +115,8 @@ describe('Whitelist testing', () => {
       target: spaceContract,
       function_selector: BigInt(getSelectorFromName(PROPOSAL_METHOD)),
       calldata: calldata2,
+      signer: [],
+      signature: [],
     });
   });
 });

--- a/test/starknet/starknet_authenticator.ts
+++ b/test/starknet/starknet_authenticator.ts
@@ -1,0 +1,93 @@
+import { ec, hash, Provider, Signer, stark } from 'starknet';
+import { SplitUint256, FOR } from './shared/types';
+import { strToShortStringArr } from '@snapshot-labs/sx';
+import { expect } from 'chai';
+import {
+  starknetSetup,
+  VITALIK_ADDRESS,
+  EXECUTE_METHOD,
+  PROPOSAL_METHOD,
+} from './shared/setup';
+import { StarknetContract } from 'hardhat/types';
+import { Account } from '@shardlabs/starknet-hardhat-plugin/dist/account';
+import { computeHashOnElements, hashCalldata } from 'starknet/dist/utils/hash';
+import { toBN } from 'starknet/dist/utils/number';
+
+const { getSelectorFromName } = stark;
+
+describe('Starknet Auth', () => {
+  let vanillaSpace: StarknetContract;
+  let starknetAuthenticator: StarknetContract;
+  let vanillaVotingStrategy: StarknetContract;
+  let zodiacRelayer: StarknetContract;
+  let account: Account;
+  const executionHash = new SplitUint256(BigInt(1), BigInt(2)); // Dummy uint256
+  const metadataUri = strToShortStringArr(
+    'Hello and welcome to Snapshot X. This is the future of governance.'
+  );
+  const proposerAddress = { value: VITALIK_ADDRESS };
+  const proposalId = 1;
+  const votingParams: Array<bigint> = [];
+  let executionParams: Array<bigint>;
+  const ethBlockNumber = BigInt(1337);
+  const l1_zodiac_module = BigInt('0xaaaaaaaaaaaa');
+  let calldata: Array<bigint>;
+  let calldata2: Array<bigint>;
+  let spaceContract: bigint;
+
+  before(async function () {
+    this.timeout(800000);
+
+    ({ vanillaSpace, starknetAuthenticator, vanillaVotingStrategy, zodiacRelayer, account } =
+      await starknetSetup());
+    executionParams = [BigInt(l1_zodiac_module)];
+    spaceContract = BigInt(vanillaSpace.address);
+
+    calldata = [
+      proposerAddress.value,
+      executionHash.low,
+      executionHash.high,
+      BigInt(metadataUri.length),
+      ...metadataUri,
+      ethBlockNumber,
+      BigInt(zodiacRelayer.address),
+      BigInt(votingParams.length),
+      ...votingParams,
+      BigInt(executionParams.length),
+      ...executionParams,
+    ];
+  });
+
+  it('Should authenticate a valid key', async () => {
+    const privateKey = stark.randomAddress();
+    const starkKeyPair = ec.getKeyPair(privateKey);
+    const defaultProvider = new Provider();
+    const addr = "";
+    const signer = new Signer(defaultProvider, addr, starkKeyPair);
+    const calldataBigNum = calldata.map((x) => toBN('0x' + x.toString(16)));
+    const msg_hash = BigInt(computeHashOnElements(calldataBigNum));
+    const sig = await signer.signMessage();
+    console.log("sig: ", sig);
+    console.log("1: ", sig[0]);
+    console.log("2: ", sig[1]);
+    await starknetAuthenticator.invoke(EXECUTE_METHOD, {
+      target: spaceContract,
+      function_selector: BigInt(getSelectorFromName(PROPOSAL_METHOD)),
+      calldata,
+      signer: [],
+      signature: [],
+    });
+  });
+
+  // it('Should NOT authenticate an INVALID key', async () => {
+  //   {
+  //     await starknetAuthenticator.invoke(EXECUTE_METHOD, {
+  //       target: spaceContract,
+  //       function_selector: BigInt(getSelectorFromName(PROPOSAL_METHOD)),
+  //       calldata,
+  //       signer: [],
+  //       signature: [],
+  //     });
+  //   }
+  // });
+});

--- a/test/starknet/vanilla_space.ts
+++ b/test/starknet/vanilla_space.ts
@@ -63,6 +63,8 @@ describe('Space testing', () => {
         target: spaceContract,
         function_selector: BigInt(getSelectorFromName(PROPOSAL_METHOD)),
         calldata,
+        signer: [],
+        signature: [],
       });
 
       console.log('Getting proposal info...');
@@ -95,6 +97,8 @@ describe('Space testing', () => {
         target: spaceContract,
         function_selector: BigInt(getSelectorFromName(VOTE_METHOD)),
         calldata: [voter_address, proposalId, FOR, BigInt(votingParams.length)],
+        signer: [],
+        signature: [],
       });
 
       console.log('Getting proposal info...');


### PR DESCRIPTION
This PR aims at adding a starknet auth (and testing it)

Current tasks:
- [x] Add starknet auth
- [ ] Testing starknet auth

The message checked is `hash_pedersen(calldata)`. This is fine for the `vote` (since it has a `proposal_id` and one can't double vote). However this is not fine for `proposal` since it doesn't hold a `proposal_id`. Need to think about that :)