### PR TITLE
Edit storage vars

### DIFF
--- a/contracts/starknet/space.cairo
+++ b/contracts/starknet/space.cairo
@@ -40,10 +40,6 @@ func proposal_threshold() -> (threshold : Uint256):
 end
 
 @storage_var
-func controller() -> (_controller : felt):
-end
-
-@storage_var
 func authenticators(authenticator_address : felt) -> (is_valid : felt):
 end
 

--- a/contracts/starknet/space.cairo
+++ b/contracts/starknet/space.cairo
@@ -313,7 +313,7 @@ func assert_valid_executor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, ran
     return ()
 end
 
-# Computes the cumulated voting power of a user by iterating (recursively) over all the voting strategies and summing the voting power on each iteration.
+# Computes the cumulated voting power of a user by iterating over the voting strategies of `used_voting_strategies`.
 # TODO: In the future we will need to transition to an array of `voter_address` because they might be different for different voting strategies.
 func get_cumulative_voting_power{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     current_timestamp : felt,

--- a/contracts/starknet/space.cairo
+++ b/contracts/starknet/space.cairo
@@ -23,9 +23,9 @@ from openzeppelin.access.ownable import (
     Ownable_only_owner, Ownable_transfer_ownership, Ownable_get_owner, Ownable_initializer
 )
 
-##
-# # Storage vars
-##
+#
+# Storage vars
+#
 
 @storage_var
 func voting_delay() -> (delay : felt):
@@ -75,9 +75,9 @@ end
 func vote_power(proposal_id : felt, choice : felt) -> (power : Uint256):
 end
 
-##
-# # Events
-##
+#
+# Events
+#
 
 @event
 func proposal_created(
@@ -150,9 +150,9 @@ end
 func voting_strategies_removed(removed_len : felt, removed : felt*):
 end
 
-##
-# # Constructor
-##
+#
+# Constructor
+#
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
@@ -208,14 +208,14 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     return ()
 end
 
-##
-# # Internal Functions
-##
+#
+#  Internal Functions
+#
 
 func unchecked_add_executors{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     to_add_len : felt, to_add : felt*
 ):
-    if to_add == 0:
+    if to_add_len == 0:
         return ()
     else:
         executors.write(to_add[0], 1)
@@ -366,9 +366,9 @@ func get_cumulative_voting_power{syscall_ptr : felt*, pedersen_ptr : HashBuiltin
     return (voting_power)
 end
 
-##
-# # External Functions
-##
+#
+# External Functions
+#
 
 @external
 func update_controller{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
@@ -794,9 +794,9 @@ func cancel_proposal{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_che
     return ()
 end
 
-##
-# # View functions
-##
+#
+# View functions
+#
 
 @view
 func get_vote_info{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(

--- a/contracts/starknet/space.cairo
+++ b/contracts/starknet/space.cairo
@@ -23,6 +23,10 @@ from openzeppelin.access.ownable import (
     Ownable_only_owner, Ownable_transfer_ownership, Ownable_get_owner, Ownable_initializer
 )
 
+##
+# # Storage vars
+##
+
 @storage_var
 func voting_delay() -> (delay : felt):
 end
@@ -36,7 +40,7 @@ func proposal_threshold() -> (threshold : Uint256):
 end
 
 @storage_var
-func voting_strategies(index : felt) -> (voting_strategy_contract : felt):
+func controller() -> (_controller : felt):
 end
 
 @storage_var
@@ -45,6 +49,10 @@ end
 
 @storage_var
 func executors(executor_address : felt) -> (is_valid : felt):
+end
+
+@storage_var
+func voting_strategies(strategy_address : felt) -> (is_valid : felt):
 end
 
 @storage_var
@@ -67,6 +75,10 @@ end
 func vote_power(proposal_id : felt, choice : felt) -> (power : Uint256):
 end
 
+##
+# # Events
+##
+
 @event
 func proposal_created(
     proposal_id : felt,
@@ -84,10 +96,6 @@ func vote_created(proposal_id : felt, voter_address : EthAddress, vote : Vote):
 end
 
 @event
-func controller_updated(new_controller : felt, previous_controller : felt):
-end
-
-@event
 func space_created(
     _voting_delay : felt,
     _voting_duration : felt,
@@ -102,169 +110,49 @@ func space_created(
 ):
 end
 
-@external
-func update_controller{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
-    new_controller : felt
-):
-    Ownable_only_owner()
-
-    let (previous_controller) = Ownable_get_owner()
-
-    Ownable_transfer_ownership(new_controller)
-
-    controller_updated.emit(new_controller, previous_controller)
-
-    return ()
+@event
+func controller_updated(previous : felt, new_controller : felt):
 end
 
-@external
-func add_executors{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
-    to_add_len : felt, to_add : felt*
-):
-    Ownable_only_owner()
-
-    register_executors(to_add_len, to_add)
-    return ()
+@event
+func voting_delay_updated(previous : felt, new_voting_delay : felt):
 end
 
-@external
-func remove_executors{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
-    to_remove_len : felt, to_remove : felt*
-):
-    Ownable_only_owner()
-
-    if to_remove_len == 0:
-        return ()
-    else:
-        executors.write(to_remove[0], 0)
-
-        remove_executors(to_remove_len - 1, &to_remove[1])
-    end
-    return ()
+@event
+func voting_duration_updated(previous : felt, new_voting_duration : felt):
 end
 
-func register_executors{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    to_register_len : felt, to_register : felt*
-):
-    if to_register_len == 0:
-        return ()
-    else:
-        executors.write(to_register[0], 1)
-
-        register_executors(to_register_len - 1, &to_register[1])
-    end
-    return ()
+@event
+func proposal_threshold_updated(previous : Uint256, new_proposal_threshold : Uint256):
 end
 
-func register_voting_strategies{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    index : felt, _voting_strategies_len : felt, _voting_strategies : felt*
-):
-    if _voting_strategies_len == 0:
-        # List is empty
-        return ()
-    else:
-        # Add voting strategy
-        voting_strategies.write(index, _voting_strategies[0])
-
-        if _voting_strategies_len == 1:
-            # Nothing left to add, end recursion
-            return ()
-        else:
-            # Recurse
-            register_voting_strategies(
-                index + 1, _voting_strategies_len - 1, &_voting_strategies[1]
-            )
-            return ()
-        end
-    end
+@event
+func authenticators_added(added_len : felt, added : felt*):
 end
 
-func register_authenticators{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    _authenticators_len : felt, _authenticators : felt*
-):
-    if _authenticators_len == 0:
-        # List is empty
-        return ()
-    else:
-        # Add voting strategy
-        authenticators.write(_authenticators[0], 1)
-
-        if _authenticators_len == 1:
-            # Nothing left to add, end recursion
-            return ()
-        else:
-            # Recurse
-            register_authenticators(_authenticators_len - 1, &_authenticators[1])
-            return ()
-        end
-    end
+@event
+func authenticators_removed(removed_len : felt, removed : felt*):
 end
 
-# Throws if the caller address is not a member of the set of whitelisted authenticators (stored in the `authenticators` mapping)
-func assert_valid_authenticator{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    ):
-    let (caller_address) = get_caller_address()
-    let (is_valid) = authenticators.read(caller_address)
-
-    # Ensure it has been initialized
-    with_attr error_message("Invalid authenticator"):
-        assert_not_zero(is_valid)
-    end
-
-    return ()
+@event
+func executors_added(added_len : felt, added : felt*):
 end
 
-# Throws if `executor` is not a member of the set of whitelisted executors (stored in the `executors` mapping)
-func assert_valid_executor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    executor : felt
-):
-    let (is_valid) = executors.read(executor)
-
-    with_attr error_message("Invalid executor"):
-        assert is_valid = 1
-    end
-
-    return ()
+@event
+func executors_removed(removed_len : felt, removed : felt*):
 end
 
-# Computes the cumulated voting power of a user by iterating (recursively) over all the voting strategies and summing the voting power on each iteration.
-func get_cumulated_voting_power{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    index : felt,
-    current_timestamp : felt,
-    voter_address : EthAddress,
-    voting_params_len : felt,
-    voting_params : felt*,
-) -> (voting_power : Uint256):
-    alloc_locals
-    # Get voting strategy contract
-    let (voting_strategy_contract) = voting_strategies.read(index)
-
-    if voting_strategy_contract == 0:
-        # Reached the end, stop iteration
-        return (Uint256(0, 0))
-    end
-
-    let (user_voting_power) = i_voting_strategy.get_voting_power(
-        contract_address=voting_strategy_contract,
-        timestamp=current_timestamp,
-        address=voter_address,
-        params_len=voting_params_len,
-        params=voting_params,
-    )
-    let (additional_voting_power) = get_cumulated_voting_power(
-        index + 1, current_timestamp, voter_address, voting_params_len, voting_params
-    )
-
-    let (voting_power, overflow) = uint256_add(user_voting_power, additional_voting_power)
-    with_attr error_message("Overflow while computing voting power"):
-        if overflow != 0:
-            # Overflow happened, revert transaction
-            assert 1 = 0
-        end
-    end
-
-    return (voting_power)
+@event
+func voting_strategies_added(added_len : felt, added : felt*):
 end
+
+@event
+func voting_strategies_removed(removed_len : felt, removed : felt*):
+end
+
+##
+# # Constructor
+##
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
@@ -298,9 +186,9 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     proposal_threshold.write(_proposal_threshold)
     Ownable_initializer(_controller)
 
-    register_voting_strategies(0, _voting_strategies_len, _voting_strategies)
-    register_authenticators(_authenticators_len, _authenticators)
-    register_executors(_executors_len, _executors)
+    unchecked_add_voting_strategies(_voting_strategies_len, _voting_strategies)
+    unchecked_add_authenticators(_authenticators_len, _authenticators)
+    unchecked_add_executors(_executors_len, _executors)
 
     next_proposal_nonce.write(1)
 
@@ -320,11 +208,317 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     return ()
 end
 
+##
+# # Internal Functions
+##
+
+func unchecked_add_executors{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    to_add_len : felt, to_add : felt*
+):
+    if to_add == 0:
+        return ()
+    else:
+        executors.write(to_add[0], 1)
+
+        unchecked_add_executors(to_add_len - 1, &to_add[1])
+        return ()
+    end
+end
+
+func unchecked_remove_executors{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt
+}(to_remove_len : felt, to_remove : felt*):
+    if to_remove_len == 0:
+        return ()
+    else:
+        executors.write(to_remove[0], 0)
+
+        unchecked_remove_executors(to_remove_len - 1, &to_remove[1])
+        return ()
+    end
+end
+
+func unchecked_add_voting_strategies{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}(to_add_len : felt, to_add : felt*):
+    if to_add_len == 0:
+        return ()
+    else:
+        voting_strategies.write(to_add[0], 1)
+
+        unchecked_add_voting_strategies(to_add_len - 1, &to_add[1])
+        return ()
+    end
+end
+
+func unchecked_remove_voting_strategies{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt
+}(to_remove_len : felt, to_remove : felt*):
+    if to_remove_len == 0:
+        return ()
+    else:
+        voting_strategies.write(to_remove[0], 0)
+
+        unchecked_remove_voting_strategies(to_remove_len - 1, &to_remove[1])
+        return ()
+    end
+end
+
+func unchecked_add_authenticators{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}(to_add_len : felt, to_add : felt*):
+    if to_add_len == 0:
+        return ()
+    else:
+        authenticators.write(to_add[0], 1)
+
+        unchecked_add_authenticators(to_add_len - 1, &to_add[1])
+        return ()
+    end
+end
+
+func unchecked_remove_authenticators{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt
+}(to_remove_len : felt, to_remove : felt*):
+    if to_remove_len == 0:
+        return ()
+    else:
+        authenticators.write(to_remove[0], 0)
+
+        unchecked_remove_authenticators(to_remove_len - 1, &to_remove[1])
+    end
+    return ()
+end
+
+# Throws if the caller address is not a member of the set of whitelisted authenticators (stored in the `authenticators` mapping)
+func assert_valid_authenticator{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    ):
+    let (caller_address) = get_caller_address()
+    let (is_valid) = authenticators.read(caller_address)
+
+    # Ensure it has been initialized
+    with_attr error_message("Invalid authenticator"):
+        assert_not_zero(is_valid)
+    end
+
+    return ()
+end
+
+# Throws if `executor` is not a member of the set of whitelisted executors (stored in the `executors` mapping)
+func assert_valid_executor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    executor : felt
+):
+    let (is_valid) = executors.read(executor)
+
+    with_attr error_message("Invalid executor"):
+        assert is_valid = 1
+    end
+
+    return ()
+end
+
+# Computes the cumulated voting power of a user by iterating (recursively) over all the voting strategies and summing the voting power on each iteration.
+# TODO: In the future we will need to transition to an array of `voter_address` because they might be different for different voting strategies.
+func get_cumulative_voting_power{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    current_timestamp : felt,
+    voter_address : EthAddress,
+    used_voting_strategies_len : felt,
+    used_voting_strategies : felt*,
+    voting_params_len : felt,
+    voting_params : felt*,
+) -> (voting_power : Uint256):
+    alloc_locals
+
+    if used_voting_strategies_len == 0:
+        # Reached the end, stop iteration
+        return (Uint256(0, 0))
+    end
+
+    let (is_valid) = voting_strategies.read(used_voting_strategies[0])
+
+    with_attr error_message("Invalid voting strategy"):
+        assert is_valid = 1
+    end
+
+    let (user_voting_power) = i_voting_strategy.get_voting_power(
+        contract_address=used_voting_strategies[0],
+        timestamp=current_timestamp,
+        address=voter_address,
+        params_len=voting_params_len,
+        params=voting_params,
+    )
+
+    let (additional_voting_power) = get_cumulative_voting_power(
+        current_timestamp,
+        voter_address,
+        used_voting_strategies_len - 1,
+        &used_voting_strategies[1],
+        voting_params_len,
+        voting_params,
+    )
+
+    let (voting_power, overflow) = uint256_add(user_voting_power, additional_voting_power)
+
+    with_attr error_message("Overflow while computing voting power"):
+        assert overflow = 0
+    end
+
+    return (voting_power)
+end
+
+##
+# # External Functions
+##
+
+@external
+func update_controller{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
+    new_controller : felt
+):
+    Ownable_only_owner()
+
+    let (previous_controller) = Ownable_get_owner()
+
+    Ownable_transfer_ownership(new_controller)
+
+    controller_updated.emit(previous_controller, new_controller)
+    return ()
+end
+
+@external
+func update_voting_delay{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
+    new_delay : felt
+):
+    Ownable_only_owner()
+
+    let (previous_delay) = voting_delay.read()
+
+    voting_delay.write(new_delay)
+
+    voting_delay_updated.emit(previous_delay, new_delay)
+
+    return ()
+end
+
+@external
+func update_voting_duration{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt
+}(new_duration : felt):
+    Ownable_only_owner()
+
+    let (previous_duration) = voting_duration.read()
+
+    voting_duration.write(new_duration)
+
+    voting_duration_updated.emit(previous_duration, new_duration)
+
+    return ()
+end
+
+@external
+func update_proposal_threshold{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt
+}(new_threshold : Uint256):
+    Ownable_only_owner()
+
+    let (previous_threshold) = proposal_threshold.read()
+
+    proposal_threshold.write(new_threshold)
+
+    proposal_threshold_updated.emit(previous_threshold, new_threshold)
+
+    return ()
+end
+
+@external
+func add_executors{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
+    to_add_len : felt, to_add : felt*
+):
+    alloc_locals
+
+    Ownable_only_owner()
+
+    unchecked_add_executors(to_add_len, to_add)
+
+    executors_added.emit(to_add_len, to_add)
+    return ()
+end
+
+@external
+func remove_executors{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
+    to_remove_len : felt, to_remove : felt*
+):
+    alloc_locals
+
+    Ownable_only_owner()
+
+    unchecked_remove_executors(to_remove_len, to_remove)
+
+    executors_removed.emit(to_remove_len, to_remove)
+    return ()
+end
+
+@external
+func add_voting_strategies{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt
+}(to_add_len : felt, to_add : felt*):
+    alloc_locals
+
+    Ownable_only_owner()
+
+    unchecked_add_voting_strategies(to_add_len, to_add)
+
+    voting_strategies_added.emit(to_add_len, to_add)
+    return ()
+end
+
+@external
+func remove_voting_strategies{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt
+}(to_remove_len : felt, to_remove : felt*):
+    alloc_locals
+
+    Ownable_only_owner()
+
+    unchecked_remove_voting_strategies(to_remove_len, to_remove)
+    voting_strategies_removed.emit(to_remove_len, to_remove)
+    return ()
+end
+
+@external
+func add_authenticators{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
+    to_add_len : felt, to_add : felt*
+):
+    alloc_locals
+
+    Ownable_only_owner()
+
+    unchecked_add_authenticators(to_add_len, to_add)
+
+    authenticators_added.emit(to_add_len, to_add)
+    return ()
+end
+
+@external
+func remove_authenticators{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt
+}(to_remove_len : felt, to_remove : felt*):
+    alloc_locals
+
+    Ownable_only_owner()
+
+    unchecked_remove_authenticators(to_remove_len, to_remove)
+
+    authenticators_removed.emit(to_remove_len, to_remove)
+    return ()
+end
+
 @external
 func vote{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
     voter_address : EthAddress,
     proposal_id : felt,
     choice : felt,
+    used_voting_strategies_len : felt,
+    used_voting_strategies : felt*,
     voting_params_len : felt,
     voting_params : felt*,
 ) -> ():
@@ -361,8 +555,13 @@ func vote{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : fe
         assert_le(choice, Choice.ABSTAIN)
     end
 
-    let (user_voting_power) = get_cumulated_voting_power(
-        0, current_timestamp, voter_address, voting_params_len, voting_params
+    let (user_voting_power) = get_cumulative_voting_power(
+        current_timestamp,
+        voter_address,
+        used_voting_strategies_len,
+        used_voting_strategies,
+        voting_params_len,
+        voting_params,
     )
 
     let (previous_voting_power) = vote_power.read(proposal_id, choice)
@@ -394,6 +593,8 @@ func propose{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr :
     metadata_uri : felt*,
     ethereum_block_number : felt,
     executor : felt,
+    used_voting_strategies_len : felt,
+    used_voting_strategies : felt*,
     voting_params_len : felt,
     voting_params : felt*,
     execution_params_len : felt,
@@ -421,8 +622,13 @@ func propose{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr :
     let start_timestamp = current_timestamp + delay
     let end_timestamp = start_timestamp + duration
 
-    let (voting_power) = get_cumulated_voting_power(
-        0, start_timestamp, proposer_address, voting_params_len, voting_params
+    let (voting_power) = get_cumulative_voting_power(
+        start_timestamp,
+        proposer_address,
+        used_voting_strategies_len,
+        used_voting_strategies,
+        voting_params_len,
+        voting_params,
     )
 
     # Verify that the proposer has enough voting power to trigger a proposal
@@ -587,6 +793,10 @@ func cancel_proposal{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_che
 
     return ()
 end
+
+##
+# # View functions
+##
 
 @view
 func get_vote_info{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(

--- a/contracts/starknet/space.cairo
+++ b/contracts/starknet/space.cairo
@@ -87,6 +87,21 @@ end
 func controller_updated(new_controller : felt, previous_controller : felt):
 end
 
+@event
+func space_created(
+    _voting_delay : felt,
+    _voting_duration : felt,
+    _proposal_threshold : Uint256,
+    _controller : felt,
+    _voting_strategies_len : felt,
+    _voting_strategies : felt*,
+    _authenticators_len : felt,
+    _authenticators : felt*,
+    _executors_len : felt,
+    _executors : felt*,
+):
+end
+
 @external
 func update_controller{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
     new_controller : felt
@@ -264,6 +279,8 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     _executors_len : felt,
     _executors : felt*,
 ):
+    alloc_locals
+
     # Sanity checks
     with_attr error_message("Invalid constructor parameters"):
         assert_nn(_voting_delay)
@@ -286,6 +303,19 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     register_executors(_executors_len, _executors)
 
     next_proposal_nonce.write(1)
+
+    space_created.emit(
+        _voting_delay,
+        _voting_duration,
+        _proposal_threshold,
+        _controller,
+        _voting_strategies_len,
+        _voting_strategies,
+        _authenticators_len,
+        _authenticators,
+        _executors_len,
+        _executors,
+    )
 
     return ()
 end

--- a/test/crosschain/eth_tx_auth.ts
+++ b/test/crosschain/eth_tx_auth.ts
@@ -7,7 +7,6 @@ import { strToShortStringArr } from '@snapshot-labs/sx';
 import { getCommit } from '../starknet/shared/helpers';
 import { ethTxAuthSetup, VITALIK_ADDRESS, VITALIK_STRING_ADDRESS } from '../starknet/shared/setup';
 import { createExecutionHash } from '../starknet/shared/helpers';
-import { Address } from 'ethereumjs-util';
 const propose_selector = BigInt(
   '0x1BFD596AE442867EF71CA523061610682AF8B00FC2738329422F4AD8D220B81'
 );

--- a/test/crosschain/eth_tx_auth.ts
+++ b/test/crosschain/eth_tx_auth.ts
@@ -7,6 +7,7 @@ import { strToShortStringArr } from '@snapshot-labs/sx';
 import { getCommit } from '../starknet/shared/helpers';
 import { ethTxAuthSetup, VITALIK_ADDRESS, VITALIK_STRING_ADDRESS } from '../starknet/shared/setup';
 import { createExecutionHash } from '../starknet/shared/helpers';
+import { Address } from 'ethereumjs-util';
 const propose_selector = BigInt(
   '0x1BFD596AE442867EF71CA523061610682AF8B00FC2738329422F4AD8D220B81'
 );
@@ -58,19 +59,6 @@ describe('L1 interaction with Snapshot X', function () {
     const eth_block_number = BigInt(1337);
     // Empty execution data
     const execution_params: Array<bigint> = [BigInt(0)];
-    propose_calldata = [
-      BigInt(signer.address),
-      executionHash.low,
-      executionHash.high,
-      BigInt(metadata_uri.length),
-      ...metadata_uri,
-      eth_block_number,
-      VITALIK_ADDRESS,
-      BigInt(voting_params.length),
-      ...voting_params,
-      BigInt(execution_params.length),
-      ...execution_params,
-    ];
     const {
       space: _space,
       ethTxAuthenticator: _ethTxAuthenticator,
@@ -83,6 +71,23 @@ describe('L1 interaction with Snapshot X', function () {
     vanillaVotingStrategy = _vanillaVotingStrategy;
     mockStarknetMessaging = _mockStarknetMessaging;
     starknetCommit = _starknetCommit;
+    const used_voting_strategies = [BigInt(vanillaVotingStrategy.address)];
+
+    propose_calldata = [
+      BigInt(signer.address),
+      executionHash.low,
+      executionHash.high,
+      BigInt(metadata_uri.length),
+      ...metadata_uri,
+      eth_block_number,
+      VITALIK_ADDRESS,
+      BigInt(used_voting_strategies.length),
+      ...used_voting_strategies,
+      BigInt(voting_params.length),
+      ...voting_params,
+      BigInt(execution_params.length),
+      ...execution_params,
+    ];
   });
 
   it('should create a proposal from an l1 tx', async () => {

--- a/test/crosschain/zodiac.ts
+++ b/test/crosschain/zodiac.ts
@@ -139,7 +139,15 @@ describe('Create proposal, cast vote, and send execution to l1', function () {
       await authContract.invoke(EXECUTE_METHOD, {
         target: BigInt(spaceContract.address),
         function_selector: BigInt(getSelectorFromName(VOTE_METHOD)),
-        calldata: [voter_address, proposal_id, FOR, BigInt(used_voting_strategies.length), ...used_voting_strategies, BigInt(votingParams.length), ...votingParams],
+        calldata: [
+          voter_address,
+          proposal_id,
+          FOR,
+          BigInt(used_voting_strategies.length),
+          ...used_voting_strategies,
+          BigInt(votingParams.length),
+          ...votingParams,
+        ],
       });
 
       const { proposal_info } = await spaceContract.call('get_proposal_info', {

--- a/test/crosschain/zodiac.ts
+++ b/test/crosschain/zodiac.ts
@@ -108,6 +108,7 @@ describe('Create proposal, cast vote, and send execution to l1', function () {
     const voting_params: Array<bigint> = [];
     const eth_block_number = BigInt(1337);
     const execution_params: Array<bigint> = [BigInt(l1Executor.address)];
+    const used_voting_strategies = [BigInt(votingContract.address)];
     const calldata = [
       proposer_address,
       executionHash.low,
@@ -116,6 +117,8 @@ describe('Create proposal, cast vote, and send execution to l1', function () {
       ...metadata_uri,
       eth_block_number,
       BigInt(zodiacRelayer.address),
+      BigInt(used_voting_strategies.length),
+      ...used_voting_strategies,
       BigInt(voting_params.length),
       ...voting_params,
       BigInt(execution_params.length),
@@ -136,7 +139,7 @@ describe('Create proposal, cast vote, and send execution to l1', function () {
       await authContract.invoke(EXECUTE_METHOD, {
         target: BigInt(spaceContract.address),
         function_selector: BigInt(getSelectorFromName(VOTE_METHOD)),
-        calldata: [voter_address, proposal_id, FOR, BigInt(votingParams.length), ...votingParams],
+        calldata: [voter_address, proposal_id, FOR, BigInt(used_voting_strategies.length), ...used_voting_strategies, BigInt(votingParams.length), ...votingParams],
       });
 
       const { proposal_info } = await spaceContract.call('get_proposal_info', {

--- a/test/starknet/executor_whitelist.ts
+++ b/test/starknet/executor_whitelist.ts
@@ -7,8 +7,6 @@ import {
   VITALIK_ADDRESS,
   EXECUTE_METHOD,
   PROPOSAL_METHOD,
-  VOTE_METHOD,
-  VOTING_DURATION,
 } from './shared/setup';
 import { StarknetContract } from 'hardhat/types';
 import { Account } from '@shardlabs/starknet-hardhat-plugin/dist/account';
@@ -31,6 +29,7 @@ describe('Whitelist testing', () => {
   let executionParams: Array<bigint>;
   const ethBlockNumber = BigInt(1337);
   const l1_zodiac_module = BigInt('0xaaaaaaaaaaaa');
+  let used_voting_strategies: Array<bigint>;
   let calldata: Array<bigint>;
   let calldata2: Array<bigint>;
   let spaceContract: bigint;
@@ -42,6 +41,7 @@ describe('Whitelist testing', () => {
       await vanillaSetup());
     executionParams = [BigInt(l1_zodiac_module)];
     spaceContract = BigInt(vanillaSpace.address);
+    used_voting_strategies = [BigInt(vanillaVotingStrategy.address)];
 
     calldata = [
       proposerAddress.value,
@@ -51,6 +51,8 @@ describe('Whitelist testing', () => {
       ...metadataUri,
       ethBlockNumber,
       BigInt(zodiacRelayer.address),
+      BigInt(used_voting_strategies.length),
+      ...used_voting_strategies,
       BigInt(votingParams.length),
       ...votingParams,
       BigInt(executionParams.length),
@@ -66,6 +68,8 @@ describe('Whitelist testing', () => {
       ...metadataUri,
       ethBlockNumber,
       VITALIK_ADDRESS,
+      BigInt(used_voting_strategies.length),
+      ...used_voting_strategies,
       BigInt(votingParams.length),
       ...votingParams,
       BigInt(executionParams.length),

--- a/test/starknet/executor_whitelist.ts
+++ b/test/starknet/executor_whitelist.ts
@@ -2,12 +2,7 @@ import { stark } from 'starknet';
 import { SplitUint256, FOR } from './shared/types';
 import { strToShortStringArr } from '@snapshot-labs/sx';
 import { expect } from 'chai';
-import {
-  vanillaSetup,
-  VITALIK_ADDRESS,
-  EXECUTE_METHOD,
-  PROPOSAL_METHOD,
-} from './shared/setup';
+import { vanillaSetup, VITALIK_ADDRESS, EXECUTE_METHOD, PROPOSAL_METHOD } from './shared/setup';
 import { StarknetContract } from 'hardhat/types';
 import { Account } from '@shardlabs/starknet-hardhat-plugin/dist/account';
 

--- a/test/starknet/vanilla_authenticator.ts
+++ b/test/starknet/vanilla_authenticator.ts
@@ -2,11 +2,6 @@ import { StarknetContract } from 'hardhat/types/runtime';
 import { starknet } from 'hardhat';
 import { stark } from 'starknet';
 
-const EXECUTE_METHOD = 'execute';
-const PROPOSAL_METHOD = 'propose';
-const VOTE_METHOD = 'vote';
-const SPACE_CONTRACT = BigInt(1337);
-
 async function setup() {
   const vanillaAuthenticatorFactory = await starknet.getContractFactory(
     './contracts/starknet/authenticators/vanilla.cairo'

--- a/test/starknet/vanilla_space.ts
+++ b/test/starknet/vanilla_space.ts
@@ -99,7 +99,15 @@ describe('Space testing', () => {
       await vanillaAuthenticator.invoke(EXECUTE_METHOD, {
         target: spaceContract,
         function_selector: BigInt(getSelectorFromName(VOTE_METHOD)),
-        calldata: [voter_address, proposalId, FOR, BigInt(used_voting_strategies.length), ...used_voting_strategies, BigInt(votingParams.length), ...votingParams],
+        calldata: [
+          voter_address,
+          proposalId,
+          FOR,
+          BigInt(used_voting_strategies.length),
+          ...used_voting_strategies,
+          BigInt(votingParams.length),
+          ...votingParams,
+        ],
       });
 
       console.log('Getting proposal info...');

--- a/test/starknet/vanilla_space.ts
+++ b/test/starknet/vanilla_space.ts
@@ -26,6 +26,7 @@ describe('Space testing', () => {
   const proposerAddress = { value: VITALIK_ADDRESS };
   const proposalId = 1;
   const votingParams: Array<bigint> = [];
+  let used_voting_strategies: Array<bigint>;
   let executionParams: Array<bigint>;
   const ethBlockNumber = BigInt(1337);
   const l1_zodiac_module = BigInt('0xaaaaaaaaaaaa');
@@ -39,6 +40,7 @@ describe('Space testing', () => {
       await vanillaSetup());
     executionParams = [BigInt(l1_zodiac_module)];
     spaceContract = BigInt(vanillaSpace.address);
+    used_voting_strategies = [BigInt(vanillaVotingStrategy.address)];
 
     calldata = [
       proposerAddress.value,
@@ -48,6 +50,8 @@ describe('Space testing', () => {
       ...metadataUri,
       ethBlockNumber,
       BigInt(zodiacRelayer.address),
+      BigInt(used_voting_strategies.length),
+      ...used_voting_strategies,
       BigInt(votingParams.length),
       ...votingParams,
       BigInt(executionParams.length),
@@ -91,10 +95,11 @@ describe('Space testing', () => {
       console.log('Casting a vote FOR...');
       const voter_address = proposerAddress.value;
       const votingparams: Array<BigInt> = [];
+      const used_voting_strategies = [BigInt(vanillaVotingStrategy.address)];
       await vanillaAuthenticator.invoke(EXECUTE_METHOD, {
         target: spaceContract,
         function_selector: BigInt(getSelectorFromName(VOTE_METHOD)),
-        calldata: [voter_address, proposalId, FOR, BigInt(votingParams.length)],
+        calldata: [voter_address, proposalId, FOR, BigInt(used_voting_strategies.length), ...used_voting_strategies, BigInt(votingParams.length), ...votingParams],
       });
 
       console.log('Getting proposal info...');


### PR DESCRIPTION
This PR:
- Allows the controller to edit all useful storage vars
- Removes the need to use an array for `voting_strategies` by using it as a mapping and requiring the user / proposer to pass in `used_voting_strategies` which is a list of the user voting strategies (contract addresses) he wants to use
- Adds events on storage vars edits AND on space creation

Closes #91 