### PR TITLE
Add starknet execution

### DIFF
--- a/contracts/starknet/execution_strategies/starknet.cairo
+++ b/contracts/starknet/execution_strategies/starknet.cairo
@@ -39,7 +39,8 @@ func execute_calls{syscall_ptr : felt*}(data_ptr : felt*, calls_len : felt, call
 
     # TODO: what should we do with the return values?
 
-    # do the next calls recursively
+    # Do the next calls recursively
+    # We subtract `4` + calls[2]` because a `call` has 4 felts and we also need to substract its associated calldata length.
     execute_calls(data_ptr, calls_len - (4 + calls[2]), calls)
 
     return ()

--- a/contracts/starknet/execution_strategies/starknet.cairo
+++ b/contracts/starknet/execution_strategies/starknet.cairo
@@ -1,6 +1,7 @@
 %lang starknet
 
 from starkware.cairo.common.uint256 import Uint256, uint256_eq
+from starkware.cairo.common.math_cmp import is_le
 from starkware.starknet.common.syscalls import call_contract
 from starkware.cairo.common.alloc import alloc
 from starkware.starknet.common.messages import send_message_to_l1
@@ -45,6 +46,7 @@ func execute_calls{syscall_ptr : felt*}(data_ptr : felt*, calls_len : felt, call
 
     return ()
 end
+
 @external
 func execute{syscall_ptr : felt*, range_check_ptr : felt}(
     proposal_outcome : felt,
@@ -53,6 +55,12 @@ func execute{syscall_ptr : felt*, range_check_ptr : felt}(
     execution_params : felt*,
 ):
     alloc_locals
+
+    # Check that there are `Calls` ton execute in the execution parameters.
+    let (is_lower) = is_le(execution_params_len, 4)
+    if is_lower == 1:
+        return ()
+    end
 
     if proposal_outcome == ProposalOutcome.ACCEPTED:
         # Check that the execution hash corresponds to the array of calls

--- a/contracts/starknet/execution_strategies/starknet.cairo
+++ b/contracts/starknet/execution_strategies/starknet.cairo
@@ -1,0 +1,76 @@
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256, uint256_eq
+from starkware.starknet.common.syscalls import call_contract
+from starkware.cairo.common.alloc import alloc
+from starkware.starknet.common.messages import send_message_to_l1
+from contracts.starknet.lib.proposal_outcome import ProposalOutcome
+from openzeppelin.account.library import AccountCallArray, Call
+
+# Starknet execution strategy
+# execution_params expected layout:
+# execution_params[0]: data_offset
+# execution_params[1]: `to`
+# execution_params[2]: `function_selector`
+# execution_params[3]: `calldata_size`
+# execution_params[4]: `calldata_offset`
+# execution_params[5]: `to` (second call)
+# execution_params[6]: `function_selector` (second call)
+# execution_params[7]: `calldata_size` (second call)
+# execution_params[8]: `calldata_offset` (second call)
+# execution_params[9]: `to` (third call)
+# etc...
+#
+# For example: say the contract wants to interact with the contract `0x123` with selector `0x456` that takes two arguments (we will give 13 and 37 as values),
+# and then interact with contract `0x789` with selector `0xabc` that takes three arguments (we will give 42 43 44 as values):
+# execution_params= [7, 0x123, 0x456, 2, 0, 0x789, 0xabc, 13, 37, 42, 43, 44]
+
+func execute_calls{syscall_ptr : felt*}(data_ptr : felt*, calls_len : felt, calls : felt*):
+    if calls_len == 0:
+        return ()
+    end
+
+    let res = call_contract(
+        contract_address=calls[0],
+        function_selector=calls[1],
+        calldata_size=calls[2],
+        calldata=&data_ptr[calls[3]],
+    )
+
+    # TODO: what should we do with the return values?
+
+    # do the next calls recursively
+    execute_calls(data_ptr, calls_len - (4 + calls[2]), calls)
+
+    return ()
+end
+@external
+func execute{syscall_ptr : felt*, range_check_ptr : felt}(
+    proposal_outcome : felt,
+    execution_hash : Uint256,
+    execution_params_len : felt,
+    execution_params : felt*,
+):
+    alloc_locals
+
+    if proposal_outcome == ProposalOutcome.ACCEPTED:
+        # Check that the execution hash corresponds to the array of calls
+        # TODO: actually check lmao
+        let recovered_hash = execution_hash
+        let (is_equal) = uint256_eq(execution_hash, recovered_hash)
+        with_attr error_message("Execution hash mismatch"):
+            assert is_equal = 1
+        end
+
+        # The calldata offset is located in the first parameter
+        let data_offset = execution_params[0]
+
+        # Execute the calls
+        execute_calls(
+            &execution_params[data_offset], execution_params_len - 1, &execution_params[1]
+        )
+        return ()
+    else:
+        return ()
+    end
+end

--- a/contracts/starknet/lib/felt_to_uint256.cairo
+++ b/contracts/starknet/lib/felt_to_uint256.cairo
@@ -1,7 +1,7 @@
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.bitwise import bitwise_and
-from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.uint256 import Uint256, uint256_check
 
 const MASK_LOW = 2 ** 128 - 1
 const MASK_HIGH = 2 ** 251 - 2 ** 128
@@ -20,4 +20,14 @@ func felt_to_uint256{bitwise_ptr : BitwiseBuiltin*, range_check_ptr}(value : fel
     let (high, _) = unsigned_div_rem(t1, SHIFT_8)
 
     return (Uint256(low=low, high=high))
+end
+
+# Converts a Uint256 to a felt
+func uint256_to_felt{range_check_ptr}(value : Uint256) -> (output : felt):
+    # Check that it's a valid felt.
+    uint256_check(value)
+
+    let res = value.low + value.high * 2 ** 128
+
+    return (res)
 end

--- a/test/starknet/executionParams.ts
+++ b/test/starknet/executionParams.ts
@@ -1,0 +1,95 @@
+import { StarknetContract } from 'hardhat/types/runtime';
+import { expect } from 'chai';
+import { starknet } from 'hardhat';
+import { createStarknetExecutionParams, Call } from './shared/executionParams';
+
+describe('Execution Parameters:', () => {
+  it('Creates a valid empty array', async () => {
+    const calls: Call[] = [];
+    const executionParams = createStarknetExecutionParams(calls);
+
+    expect(executionParams).to.deep.equal([]);
+  }).timeout(600000);
+
+  it('Creates a valid array with a single call', async () => {
+    const call = {
+      to: BigInt('0x123'),
+      functionSelector: BigInt('0x456'),
+      calldata: [BigInt(1), BigInt(2)],
+    };
+    const calls: Call[] = [call];
+    const executionParams = createStarknetExecutionParams(calls);
+    const expected = [
+      BigInt(5),
+      call.to,
+      call.functionSelector,
+      BigInt(call.calldata.length),
+      BigInt(0),
+      ...call.calldata,
+    ];
+
+    expect(executionParams).to.deep.equal(expected);
+  }).timeout(600000);
+
+  it('Creates a valid array with two calls', async () => {
+    const call1 = {
+      to: BigInt('0x123'),
+      functionSelector: BigInt('0x456'),
+      calldata: [BigInt(1), BigInt(2)],
+    };
+    const call2 = { to: BigInt('0x789'), functionSelector: BigInt('0xabc'), calldata: [] };
+    const calls: Call[] = [call1, call2];
+    const executionParams = createStarknetExecutionParams(calls);
+    const expected = [
+      BigInt(9),
+      call1.to,
+      call1.functionSelector,
+      BigInt(call1.calldata.length),
+      BigInt(0),
+      call2.to,
+      call2.functionSelector,
+      BigInt(call2.calldata.length),
+      BigInt(call1.calldata.length),
+      ...call1.calldata,
+      ...call2.calldata,
+    ];
+
+    expect(executionParams).to.deep.equal(expected);
+  }).timeout(600000);
+
+  it('Creates a valid array with three calls', async () => {
+    const call1 = {
+      to: BigInt('0x123'),
+      functionSelector: BigInt('0x456'),
+      calldata: [BigInt(1), BigInt(2)],
+    };
+    const call2 = { to: BigInt('0x789'), functionSelector: BigInt('0xabc'), calldata: [] };
+    const call3 = {
+      to: BigInt('0xaaa'),
+      functionSelector: BigInt('0xbbb'),
+      calldata: [BigInt(3), BigInt(4)],
+    };
+    const calls: Call[] = [call1, call2, call3];
+    const executionParams = createStarknetExecutionParams(calls);
+    const expected = [
+      BigInt(13),
+      call1.to,
+      call1.functionSelector,
+      BigInt(call1.calldata.length),
+      BigInt(0),
+      call2.to,
+      call2.functionSelector,
+      BigInt(call2.calldata.length),
+      BigInt(call1.calldata.length),
+      call3.to,
+      call3.functionSelector,
+      BigInt(call3.calldata.length),
+      BigInt(call1.calldata.length + call2.calldata.length),
+      ...call1.calldata,
+      ...call2.calldata,
+      ...call3.calldata,
+    ];
+
+    expect(executionParams).to.deep.equal(expected);
+  }).timeout(600000);
+});

--- a/test/starknet/shared/executionParams.ts
+++ b/test/starknet/shared/executionParams.ts
@@ -1,0 +1,39 @@
+export interface Call {
+  to: bigint;
+  functionSelector: bigint;
+  calldata: bigint[];
+}
+
+/**
+ * For more info about the starknetExecutionParams layout, please see `contracts/starknet/execution_strategies/starknet.cairo`.
+ */
+export function createStarknetExecutionParams(callArray: Call[]): bigint[] {
+  if (!callArray || callArray.length == 0) {
+    return [];
+  }
+
+  // 1 because we need to count data_offset
+  // 4 because there are four elements: `to`, `function_selector`, `calldata_len` and `calldata_offset`
+  const dataOffset = BigInt(1 + callArray.length * 4);
+
+  const executionParams = [dataOffset];
+  let calldataIndex = 0;
+
+  // First, layout the calls
+  callArray.forEach((call) => {
+    const subArr: bigint[] = [
+      call.to,
+      call.functionSelector,
+      BigInt(call.calldata.length),
+      BigInt(calldataIndex),
+    ];
+    calldataIndex += call.calldata.length;
+    executionParams.push(...subArr);
+  });
+
+  // Then layout the calldata
+  callArray.forEach((call) => {
+    executionParams.push(...call.calldata);
+  });
+  return executionParams;
+}

--- a/test/starknet/shared/setup.ts
+++ b/test/starknet/shared/setup.ts
@@ -329,3 +329,63 @@ async function fossilSetup(account: Account) {
   });
   return new Fossil(factsRegistry, l1HeadersStore, l1RelayerAccount);
 }
+
+export async function starknetExecSetup() {
+  const account = await starknet.deployAccount('OpenZeppelin');
+
+  const vanillaSpaceFactory = await starknet.getContractFactory('./contracts/starknet/space.cairo');
+  const vanillaVotingStategyFactory = await starknet.getContractFactory(
+    './contracts/starknet/voting_strategies/vanilla.cairo'
+  );
+  const vanillaAuthenticatorFactory = await starknet.getContractFactory(
+    './contracts/starknet/authenticators/vanilla.cairo'
+  );
+  const starknetExecFactory = await starknet.getContractFactory(
+    './contracts/starknet/execution_strategies/starknet.cairo'
+  );
+
+  const deployments = [
+    vanillaAuthenticatorFactory.deploy(),
+    vanillaVotingStategyFactory.deploy(),
+    starknetExecFactory.deploy(),
+  ];
+  console.log('Deploying auth, voting and starknet execution contracts...');
+  const contracts = await Promise.all(deployments);
+  const vanillaAuthenticator = contracts[0] as StarknetContract;
+  const vanillaVotingStrategy = contracts[1] as StarknetContract;
+  const starknetExec = contracts[2] as StarknetContract;
+
+  const voting_strategy = BigInt(vanillaVotingStrategy.address);
+  const voting_strategy_params: bigint[][] = [[]];
+  const voting_strategy_params_flat = flatten2DArray(voting_strategy_params);
+  const authenticator = BigInt(vanillaAuthenticator.address);
+  const starknet_exec = BigInt(starknetExec.address);
+  const quorum = SplitUint256.fromUint(BigInt(0));
+
+  // This should be declared along with the other const but doing so will make the compiler unhappy as `SplitUin256`
+  // will be undefined for some reason?
+  const PROPOSAL_THRESHOLD = SplitUint256.fromUint(BigInt(1));
+
+  console.log('Deploying space contract...');
+  const vanillaSpace = (await vanillaSpaceFactory.deploy({
+    _voting_delay: VOTING_DELAY,
+    _min_voting_duration: MIN_VOTING_DURATION,
+    _max_voting_duration: MAX_VOTING_DURATION,
+    _proposal_threshold: PROPOSAL_THRESHOLD,
+    _controller: BigInt(account.starknetContract.address),
+    _quorum: quorum,
+    _voting_strategy_params_flat: voting_strategy_params_flat,
+    _voting_strategies: [voting_strategy],
+    _authenticators: [authenticator],
+    _executors: [starknet_exec],
+  })) as StarknetContract;
+  console.log('deployed!');
+
+  return {
+    vanillaSpace,
+    vanillaAuthenticator,
+    vanillaVotingStrategy,
+    starknetExec,
+    account,
+  };
+}

--- a/test/starknet/starknet_execution.ts
+++ b/test/starknet/starknet_execution.ts
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 import {
   vanillaSetup,
   VITALIK_ADDRESS,
-  EXECUTE_METHOD,
+  AUTHENTICATE_METHOD,
   PROPOSAL_METHOD,
   VOTE_METHOD,
   MIN_VOTING_DURATION,
@@ -71,7 +71,7 @@ describe('Starknet Execution', () => {
     // To better understand how this is constructed, please read the Starknet execution strategy comments.
     const call: Call = {
       to: BigInt(vanillaAuthenticator.address),
-      functionSelector: BigInt(getSelectorFromName(EXECUTE_METHOD)),
+      functionSelector: BigInt(getSelectorFromName(AUTHENTICATE_METHOD)),
       calldata: [
         spaceContract,
         BigInt(getSelectorFromName(PROPOSAL_METHOD)),
@@ -105,7 +105,7 @@ describe('Starknet Execution', () => {
     // -- Creates the proposal --
     {
       console.log('Creating proposal...');
-      await vanillaAuthenticator.invoke(EXECUTE_METHOD, {
+      await vanillaAuthenticator.invoke(AUTHENTICATE_METHOD, {
         target: spaceContract,
         function_selector: BigInt(getSelectorFromName(PROPOSAL_METHOD)),
         calldata,
@@ -137,7 +137,7 @@ describe('Starknet Execution', () => {
       // Cairo cannot handle 2D arrays in calldata so we must flatten the data then reconstruct the individual arrays inside the contract
       const votingParamsAllFlat = flatten2DArray(votingParamsAll);
       const used_voting_strategies = [BigInt(vanillaVotingStrategy.address)];
-      await vanillaAuthenticator.invoke(EXECUTE_METHOD, {
+      await vanillaAuthenticator.invoke(AUTHENTICATE_METHOD, {
         target: spaceContract,
         function_selector: BigInt(getSelectorFromName(VOTE_METHOD)),
         calldata: [
@@ -182,7 +182,7 @@ describe('Starknet Execution', () => {
       // Cairo cannot handle 2D arrays in calldata so we must flatten the data then reconstruct the individual arrays inside the contract
       const votingParamsAllFlat = flatten2DArray(votingParamsAll);
       const used_voting_strategies = [BigInt(vanillaVotingStrategy.address)];
-      await vanillaAuthenticator.invoke(EXECUTE_METHOD, {
+      await vanillaAuthenticator.invoke(AUTHENTICATE_METHOD, {
         target: spaceContract,
         function_selector: BigInt(getSelectorFromName(VOTE_METHOD)),
         calldata: [

--- a/test/starknet/starknet_execution.ts
+++ b/test/starknet/starknet_execution.ts
@@ -1,0 +1,214 @@
+import { stark } from 'starknet';
+import { SplitUint256, FOR } from './shared/types';
+import { flatten2DArray } from './shared/helpers';
+import { strToShortStringArr } from '@snapshot-labs/sx';
+import { expect } from 'chai';
+import {
+  vanillaSetup,
+  VITALIK_ADDRESS,
+  EXECUTE_METHOD,
+  PROPOSAL_METHOD,
+  VOTE_METHOD,
+  MIN_VOTING_DURATION,
+  MAX_VOTING_DURATION,
+  starknetExecSetup,
+} from './shared/setup';
+import { StarknetContract } from 'hardhat/types';
+import { executionAsyncId } from 'async_hooks';
+import { starknet } from 'hardhat';
+
+const { getSelectorFromName } = stark;
+
+describe('Starknet Execution', () => {
+  let vanillaSpace: StarknetContract;
+  let vanillaAuthenticator: StarknetContract;
+  let vanillaVotingStrategy: StarknetContract;
+  let starknetExec: StarknetContract;
+  const executionHash = new SplitUint256(BigInt(1), BigInt(2)); // Dummy uint256
+  const metadataUri = strToShortStringArr(
+    'Hello and welcome to Snapshot X. This is the future of governance.'
+  );
+  const proposerAddress = { value: VITALIK_ADDRESS };
+  const proposalId = 1;
+  const votingParamsAll: bigint[][] = [[]];
+  let used_voting_strategies: Array<bigint>;
+  let executionParams: Array<bigint>;
+  const ethBlockNumber = BigInt(1337);
+  let calldata: Array<bigint>;
+  let spaceContract: bigint;
+
+  before(async function () {
+    this.timeout(800000);
+
+    ({ vanillaSpace, vanillaAuthenticator, vanillaVotingStrategy, starknetExec } =
+      await starknetExecSetup());
+
+    spaceContract = BigInt(vanillaSpace.address);
+    used_voting_strategies = [BigInt(vanillaVotingStrategy.address)];
+
+    // Cairo cannot handle 2D arrays in calldata so we must flatten the data then reconstruct the individual arrays inside the contract
+    const votingParamsAllFlat = flatten2DArray(votingParamsAll);
+    executionParams = [];
+
+    const call_calldata = [
+      proposerAddress.value,
+      executionHash.low,
+      executionHash.high,
+      BigInt(metadataUri.length),
+      ...metadataUri,
+      ethBlockNumber,
+      BigInt(starknetExec.address),
+      BigInt(used_voting_strategies.length),
+      ...used_voting_strategies,
+      BigInt(votingParamsAllFlat.length),
+      ...votingParamsAllFlat,
+      BigInt(executionParams.length),
+      ...executionParams,
+    ];
+
+    // To better understand how this is constructed, please read the Starknet execution strategy comments.
+    const call = {
+      to: BigInt(vanillaAuthenticator.address),
+      selector: getSelectorFromName(EXECUTE_METHOD),
+      calldata: [
+        spaceContract,
+        BigInt(getSelectorFromName(PROPOSAL_METHOD)),
+        BigInt(call_calldata.length),
+        ...call_calldata,
+      ],
+    };
+    executionParams = [
+      BigInt(5),
+      call.to,
+      BigInt(call.selector),
+      BigInt(call.calldata.length),
+      BigInt(0),
+      ...call.calldata,
+    ];
+
+    calldata = [
+      proposerAddress.value,
+      executionHash.low,
+      executionHash.high,
+      BigInt(metadataUri.length),
+      ...metadataUri,
+      ethBlockNumber,
+      BigInt(starknetExec.address),
+      BigInt(used_voting_strategies.length),
+      ...used_voting_strategies,
+      BigInt(votingParamsAllFlat.length),
+      ...votingParamsAllFlat,
+      BigInt(executionParams.length),
+      ...executionParams,
+    ];
+  });
+
+  it('Should create a proposal, cast a vote, execute the proposal, and vote on the newly created proposal', async () => {
+    // -- Creates the proposal --
+    {
+      console.log('Creating proposal...');
+      await vanillaAuthenticator.invoke(EXECUTE_METHOD, {
+        target: spaceContract,
+        function_selector: BigInt(getSelectorFromName(PROPOSAL_METHOD)),
+        calldata,
+      });
+
+      console.log('Getting proposal info...');
+      const { proposal_info } = await vanillaSpace.call('get_proposal_info', {
+        proposal_id: proposalId,
+      });
+
+      // We can't directly compare the `info` object because we don't know for sure the value of `start_block` (and hence `end_block`),
+      // so we compare it element by element.
+      const _executionHash = SplitUint256.fromObj(proposal_info.proposal.execution_hash);
+      expect(_executionHash).to.deep.equal(executionHash);
+
+      const _for = SplitUint256.fromObj(proposal_info.power_for).toUint();
+      expect(_for).to.deep.equal(BigInt(0));
+      const against = SplitUint256.fromObj(proposal_info.power_against).toUint();
+      expect(against).to.deep.equal(BigInt(0));
+      const abstain = SplitUint256.fromObj(proposal_info.power_abstain).toUint();
+      expect(abstain).to.deep.equal(BigInt(0));
+    }
+
+    // -- Casts a vote FOR --
+    {
+      console.log('Casting a vote FOR...');
+      const voter_address = proposerAddress.value;
+      const votingParamsAll: bigint[][] = [[]];
+      // Cairo cannot handle 2D arrays in calldata so we must flatten the data then reconstruct the individual arrays inside the contract
+      const votingParamsAllFlat = flatten2DArray(votingParamsAll);
+      const used_voting_strategies = [BigInt(vanillaVotingStrategy.address)];
+      await vanillaAuthenticator.invoke(EXECUTE_METHOD, {
+        target: spaceContract,
+        function_selector: BigInt(getSelectorFromName(VOTE_METHOD)),
+        calldata: [
+          voter_address,
+          proposalId,
+          FOR,
+          BigInt(used_voting_strategies.length),
+          ...used_voting_strategies,
+          BigInt(votingParamsAllFlat.length),
+          ...votingParamsAllFlat,
+        ],
+      });
+
+      console.log('Getting proposal info...');
+      const { proposal_info } = await vanillaSpace.call('get_proposal_info', {
+        proposal_id: proposalId,
+      });
+
+      const _for = SplitUint256.fromObj(proposal_info.power_for).toUint();
+      expect(_for).to.deep.equal(BigInt(1));
+      const against = SplitUint256.fromObj(proposal_info.power_against).toUint();
+      expect(against).to.deep.equal(BigInt(0));
+      const abstain = SplitUint256.fromObj(proposal_info.power_abstain).toUint();
+      expect(abstain).to.deep.equal(BigInt(0));
+    }
+
+    // -- Finalize Proposal and execute --
+    {
+      console.log('Finalizing proposal');
+      await vanillaSpace.invoke('finalize_proposal', {
+        proposal_id: 1,
+        execution_params: executionParams,
+      });
+    }
+
+    // -- Execution should have created a new proposal; vote on it!
+    {
+      console.log('Casting a vote FOR...');
+      const newProposalId = proposalId + 1;
+      const voter_address = proposerAddress.value;
+      const votingParamsAll: bigint[][] = [[]];
+      // Cairo cannot handle 2D arrays in calldata so we must flatten the data then reconstruct the individual arrays inside the contract
+      const votingParamsAllFlat = flatten2DArray(votingParamsAll);
+      const used_voting_strategies = [BigInt(vanillaVotingStrategy.address)];
+      await vanillaAuthenticator.invoke(EXECUTE_METHOD, {
+        target: spaceContract,
+        function_selector: BigInt(getSelectorFromName(VOTE_METHOD)),
+        calldata: [
+          voter_address,
+          newProposalId,
+          FOR,
+          BigInt(used_voting_strategies.length),
+          ...used_voting_strategies,
+          BigInt(votingParamsAllFlat.length),
+          ...votingParamsAllFlat,
+        ],
+      });
+
+      console.log('Getting proposal info...');
+      const { proposal_info } = await vanillaSpace.call('get_proposal_info', {
+        proposal_id: newProposalId,
+      });
+
+      const _for = SplitUint256.fromObj(proposal_info.power_for).toUint();
+      expect(_for).to.deep.equal(BigInt(1));
+      const against = SplitUint256.fromObj(proposal_info.power_against).toUint();
+      expect(against).to.deep.equal(BigInt(0));
+      const abstain = SplitUint256.fromObj(proposal_info.power_abstain).toUint();
+      expect(abstain).to.deep.equal(BigInt(0));
+    }
+  }).timeout(6000000);
+});

--- a/test/starknet/starknet_execution.ts
+++ b/test/starknet/starknet_execution.ts
@@ -15,8 +15,8 @@ import {
   starknetExecSetup,
 } from './shared/setup';
 import { StarknetContract } from 'hardhat/types';
-import { executionAsyncId } from 'async_hooks';
-import { starknet } from 'hardhat';
+import { computeHashOnElements } from 'starknet/dist/utils/hash';
+import { toBN } from 'starknet/dist/utils/number';
 
 const { getSelectorFromName } = stark;
 
@@ -25,7 +25,7 @@ describe('Starknet Execution', () => {
   let vanillaAuthenticator: StarknetContract;
   let vanillaVotingStrategy: StarknetContract;
   let starknetExec: StarknetContract;
-  const executionHash = new SplitUint256(BigInt(1), BigInt(2)); // Dummy uint256
+  let executionHash: SplitUint256;
   const metadataUri = strToShortStringArr(
     'Hello and welcome to Snapshot X. This is the future of governance.'
   );
@@ -51,6 +51,7 @@ describe('Starknet Execution', () => {
     const votingParamsAllFlat = flatten2DArray(votingParamsAll);
     const emptyExecutionParams: bigint[] = [];
 
+    executionHash = new SplitUint256(BigInt(1), BigInt(2)); // Dummy
     const call_calldata = [
       proposerAddress.value,
       executionHash.low,
@@ -80,6 +81,8 @@ describe('Starknet Execution', () => {
     };
     const calls = [call];
     executionParams = createStarknetExecutionParams(calls);
+    const executionParamsBN = executionParams.map((n) => toBN(n.toString()));
+    executionHash = SplitUint256.fromUint(BigInt(computeHashOnElements(executionParamsBN)));
 
     calldata = [
       proposerAddress.value,


### PR DESCRIPTION
This PR adds what we call "starknet execution": the ability to create a proposal and specify some starknet transactions to automatically execute if this proposal passes.
The execution parameter layout is a bit tricky but is completely detailed in the `starknet.cairo` execution strategy file.

Here are the desired steps in order to get this right:

- [x] Basic execution (create a proposal that will in turn create a new proposal if executed. Execute it and verify that the new proposal has been created)
- [x] Verify the hash
- [ ] Add a test to modify internal settings (like quorum)
- [ ] Add a test to execute MULTIPLE transactions
- [ ] Decide what to do with the results of the successive `calls` (imho nothing, but still we need to ask ourselves the question)

Closes #93 