### PR TITLE
Add starknet execution

### DIFF
--- a/contracts/starknet/ExecutionStrategies/Starknet.cairo
+++ b/contracts/starknet/ExecutionStrategies/Starknet.cairo
@@ -1,19 +1,17 @@
 %lang starknet
 
-from starkware.cairo.common.uint256 import Uint256, uint256_eq
 from starkware.cairo.common.math_cmp import is_le
 from starkware.starknet.common.syscalls import call_contract
 from starkware.cairo.common.alloc import alloc
-from starkware.starknet.common.messages import send_message_to_l1
 from contracts.starknet.lib.proposal_outcome import ProposalOutcome
-from contracts.starknet.lib.hash_array import hash_array
-from starkware.cairo.common.cairo_builtins import HashBuiltin
-from openzeppelin.account.library import AccountCallArray, Call
 
-# For example: say the contract wants to interact with the contract `0x123` with selector `0x456` that takes two arguments (we will give 13 and 37 as values),
+# Starknet Execution
+# This is more of a demo as we need to interact with a wallet to execute meaningful transactions.
+
+# Example execution: say the contract wants to interact with the contract `0x123` with selector `0x456` that takes two arguments (we will give 13 and 37 as values),
 # and then interact with contract `0x789` with selector `0xabc` that takes three arguments (we will give 42 43 44 as values):
-# [0x123, 0x456, 2, 13, 37, 0x789, 0xabc, 3, 42, 43, 44]
-func execute_calls{syscall_ptr : felt*}(calls_len : felt, calls : felt*):
+# [9, 0x123, 0x456, 2, 0, 0x789, 0xabc, 3, 2, 13, 37, 42, 43, 44]
+func execute_calls{syscall_ptr : felt*}(data_ptr : felt*, calls_len : felt, calls : felt*):
     if calls_len == 0:
         return ()
     end
@@ -22,18 +20,20 @@ func execute_calls{syscall_ptr : felt*}(calls_len : felt, calls : felt*):
         contract_address=calls[0],
         function_selector=calls[1],
         calldata_size=calls[2],
-        calldata=&calls[3],
+        calldata=&data_ptr[calls[3]],
     )
 
     # TODO: what should we do with the return values?
 
-    execute_calls(calls_len - 3 - calls[2], calls + 3 + calls[2])
+    # Do the next calls recursively
+    # We subtract `4` + calls[2]` because a `call` has 4 felts and we also need to substract its associated calldata length.
+    execute_calls(data_ptr, calls_len - (4 + calls[2]), calls + 4)
 
     return ()
 end
 
 @external
-func execute{syscall_ptr : felt*, range_check_ptr : felt, pedersen_ptr : HashBuiltin*}(
+func execute{syscall_ptr : felt*, range_check_ptr : felt}(
     proposal_outcome : felt, execution_params_len : felt, execution_params : felt*
 ):
     alloc_locals
@@ -44,57 +44,15 @@ func execute{syscall_ptr : felt*, range_check_ptr : felt, pedersen_ptr : HashBui
     end
 
     if proposal_outcome == ProposalOutcome.ACCEPTED:
+        # The calldata offset is located in the first parameter
+        let data_offset = execution_params[0]
+
         # Execute the calls
-        execute_calls(execution_params_len, execution_params)
+        execute_calls(
+            &execution_params[data_offset], execution_params_len - 1, &execution_params[1]
+        )
         return ()
     else:
         return ()
     end
 end
-
-# func execute_calls{syscall_ptr : felt*}(data_ptr : felt*, calls_len : felt, calls : felt*):
-#     if calls_len == 0:
-#         return ()
-#     end
-
-# let res = call_contract(
-#         contract_address=calls[0],
-#         function_selector=calls[1],
-#         calldata_size=calls[2],
-#         calldata=&data_ptr[calls[3]],
-#     )
-
-# # TODO: what should we do with the return values?
-
-# # Do the next calls recursively
-#     # We subtract `4` + calls[2]` because a `call` has 4 felts and we also need to substract its associated calldata length.
-#     execute_calls(data_ptr, calls_len - (4 + calls[2]), calls + 4)
-
-# return ()
-# end
-
-# @external
-# func execute{syscall_ptr : felt*, range_check_ptr : felt, pedersen_ptr : HashBuiltin*}(
-#     proposal_outcome : felt, execution_params_len : felt, execution_params : felt*
-# ):
-#     alloc_locals
-#     # assert execution_params_len = 1
-#     # Check that there are `Calls` ton execute in the execution parameters.
-#     let (is_lower) = is_le(execution_params_len, 4)
-#     if is_lower == 1:
-#         return ()
-#     end
-
-# if proposal_outcome == ProposalOutcome.ACCEPTED:
-#         # The calldata offset is located in the first parameter
-#         let data_offset = execution_params[0]
-
-# # Execute the calls
-#         execute_calls(
-#             &execution_params[data_offset], execution_params_len - 1, &execution_params[1]
-#         )
-#         return ()
-#     else:
-#         return ()
-#     end
-# end

--- a/contracts/starknet/ExecutionStrategies/Starknet.cairo
+++ b/contracts/starknet/ExecutionStrategies/Starknet.cairo
@@ -54,7 +54,7 @@ func execute{syscall_ptr : felt*, range_check_ptr : felt, pedersen_ptr : HashBui
     proposal_outcome : felt, execution_params_len : felt, execution_params : felt*
 ):
     alloc_locals
-
+    # assert execution_params_len = 1
     # Check that there are `Calls` ton execute in the execution parameters.
     let (is_lower) = is_le(execution_params_len, 4)
     if is_lower == 1:

--- a/contracts/starknet/ExecutionStrategies/Starknet.cairo
+++ b/contracts/starknet/ExecutionStrategies/Starknet.cairo
@@ -10,25 +10,10 @@ from contracts.starknet.lib.hash_array import hash_array
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from openzeppelin.account.library import AccountCallArray, Call
 
-# Starknet execution strategy
-# execution_params expected layout:
-# execution_params[0]: data_offset
-# execution_params[1]: `to`
-# execution_params[2]: `function_selector`
-# execution_params[3]: `calldata_size`
-# execution_params[4]: `calldata_offset`
-# execution_params[5]: `to` (second call)
-# execution_params[6]: `function_selector` (second call)
-# execution_params[7]: `calldata_size` (second call)
-# execution_params[8]: `calldata_offset` (second call)
-# execution_params[9]: `to` (third call)
-# etc...
-#
 # For example: say the contract wants to interact with the contract `0x123` with selector `0x456` that takes two arguments (we will give 13 and 37 as values),
 # and then interact with contract `0x789` with selector `0xabc` that takes three arguments (we will give 42 43 44 as values):
-# execution_params= [9, [0x123, 0x456, 2, 0, [0x789, 0xabc, 3, 2, 13, 37, 42, 43, 44]
-
-func execute_calls{syscall_ptr : felt*}(data_ptr : felt*, calls_len : felt, calls : felt*):
+# [0x123, 0x456, 2, 13, 37, 0x789, 0xabc, 3, 42, 43, 44]
+func execute_calls{syscall_ptr : felt*}(calls_len : felt, calls : felt*):
     if calls_len == 0:
         return ()
     end
@@ -37,14 +22,12 @@ func execute_calls{syscall_ptr : felt*}(data_ptr : felt*, calls_len : felt, call
         contract_address=calls[0],
         function_selector=calls[1],
         calldata_size=calls[2],
-        calldata=&data_ptr[calls[3]],
+        calldata=&calls[3],
     )
 
     # TODO: what should we do with the return values?
 
-    # Do the next calls recursively
-    # We subtract `4` + calls[2]` because a `call` has 4 felts and we also need to substract its associated calldata length.
-    execute_calls(data_ptr, calls_len - (4 + calls[2]), calls + 4)
+    execute_calls(calls_len - 3 - calls[2], calls + 3 + calls[2])
 
     return ()
 end
@@ -54,7 +37,6 @@ func execute{syscall_ptr : felt*, range_check_ptr : felt, pedersen_ptr : HashBui
     proposal_outcome : felt, execution_params_len : felt, execution_params : felt*
 ):
     alloc_locals
-    # assert execution_params_len = 1
     # Check that there are `Calls` ton execute in the execution parameters.
     let (is_lower) = is_le(execution_params_len, 4)
     if is_lower == 1:
@@ -62,15 +44,57 @@ func execute{syscall_ptr : felt*, range_check_ptr : felt, pedersen_ptr : HashBui
     end
 
     if proposal_outcome == ProposalOutcome.ACCEPTED:
-        # The calldata offset is located in the first parameter
-        let data_offset = execution_params[0]
-
         # Execute the calls
-        execute_calls(
-            &execution_params[data_offset], execution_params_len - 1, &execution_params[1]
-        )
+        execute_calls(execution_params_len, execution_params)
         return ()
     else:
         return ()
     end
 end
+
+# func execute_calls{syscall_ptr : felt*}(data_ptr : felt*, calls_len : felt, calls : felt*):
+#     if calls_len == 0:
+#         return ()
+#     end
+
+# let res = call_contract(
+#         contract_address=calls[0],
+#         function_selector=calls[1],
+#         calldata_size=calls[2],
+#         calldata=&data_ptr[calls[3]],
+#     )
+
+# # TODO: what should we do with the return values?
+
+# # Do the next calls recursively
+#     # We subtract `4` + calls[2]` because a `call` has 4 felts and we also need to substract its associated calldata length.
+#     execute_calls(data_ptr, calls_len - (4 + calls[2]), calls + 4)
+
+# return ()
+# end
+
+# @external
+# func execute{syscall_ptr : felt*, range_check_ptr : felt, pedersen_ptr : HashBuiltin*}(
+#     proposal_outcome : felt, execution_params_len : felt, execution_params : felt*
+# ):
+#     alloc_locals
+#     # assert execution_params_len = 1
+#     # Check that there are `Calls` ton execute in the execution parameters.
+#     let (is_lower) = is_le(execution_params_len, 4)
+#     if is_lower == 1:
+#         return ()
+#     end
+
+# if proposal_outcome == ProposalOutcome.ACCEPTED:
+#         # The calldata offset is located in the first parameter
+#         let data_offset = execution_params[0]
+
+# # Execute the calls
+#         execute_calls(
+#             &execution_params[data_offset], execution_params_len - 1, &execution_params[1]
+#         )
+#         return ()
+#     else:
+#         return ()
+#     end
+# end

--- a/contracts/starknet/ExecutionStrategies/Starknet.cairo
+++ b/contracts/starknet/ExecutionStrategies/Starknet.cairo
@@ -1,0 +1,76 @@
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256, uint256_eq
+from starkware.cairo.common.math_cmp import is_le
+from starkware.starknet.common.syscalls import call_contract
+from starkware.cairo.common.alloc import alloc
+from starkware.starknet.common.messages import send_message_to_l1
+from contracts.starknet.lib.proposal_outcome import ProposalOutcome
+from contracts.starknet.lib.hash_array import hash_array
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from openzeppelin.account.library import AccountCallArray, Call
+
+# Starknet execution strategy
+# execution_params expected layout:
+# execution_params[0]: data_offset
+# execution_params[1]: `to`
+# execution_params[2]: `function_selector`
+# execution_params[3]: `calldata_size`
+# execution_params[4]: `calldata_offset`
+# execution_params[5]: `to` (second call)
+# execution_params[6]: `function_selector` (second call)
+# execution_params[7]: `calldata_size` (second call)
+# execution_params[8]: `calldata_offset` (second call)
+# execution_params[9]: `to` (third call)
+# etc...
+#
+# For example: say the contract wants to interact with the contract `0x123` with selector `0x456` that takes two arguments (we will give 13 and 37 as values),
+# and then interact with contract `0x789` with selector `0xabc` that takes three arguments (we will give 42 43 44 as values):
+# execution_params= [9, [0x123, 0x456, 2, 0, [0x789, 0xabc, 3, 2, 13, 37, 42, 43, 44]
+
+func execute_calls{syscall_ptr : felt*}(data_ptr : felt*, calls_len : felt, calls : felt*):
+    if calls_len == 0:
+        return ()
+    end
+
+    let res = call_contract(
+        contract_address=calls[0],
+        function_selector=calls[1],
+        calldata_size=calls[2],
+        calldata=&data_ptr[calls[3]],
+    )
+
+    # TODO: what should we do with the return values?
+
+    # Do the next calls recursively
+    # We subtract `4` + calls[2]` because a `call` has 4 felts and we also need to substract its associated calldata length.
+    execute_calls(data_ptr, calls_len - (4 + calls[2]), calls + 4)
+
+    return ()
+end
+
+@external
+func execute{syscall_ptr : felt*, range_check_ptr : felt, pedersen_ptr : HashBuiltin*}(
+    proposal_outcome : felt, execution_params_len : felt, execution_params : felt*
+):
+    alloc_locals
+
+    # Check that there are `Calls` ton execute in the execution parameters.
+    let (is_lower) = is_le(execution_params_len, 4)
+    if is_lower == 1:
+        return ()
+    end
+
+    if proposal_outcome == ProposalOutcome.ACCEPTED:
+        # The calldata offset is located in the first parameter
+        let data_offset = execution_params[0]
+
+        # Execute the calls
+        execute_calls(
+            &execution_params[data_offset], execution_params_len - 1, &execution_params[1]
+        )
+        return ()
+    else:
+        return ()
+    end
+end

--- a/contracts/starknet/ExecutionStrategies/Vanilla.cairo
+++ b/contracts/starknet/ExecutionStrategies/Vanilla.cairo
@@ -4,10 +4,7 @@ from starkware.cairo.common.uint256 import Uint256
 
 @external
 func execute{syscall_ptr : felt*}(
-    proposal_outcome : felt,
-    execution_hash : Uint256,
-    execution_params_len : felt,
-    execution_params : felt*,
+    proposal_outcome : felt, execution_params_len : felt, execution_params : felt*
 ):
     return ()
 end

--- a/contracts/starknet/ExecutionStrategies/ZodiacRelayer.cairo
+++ b/contracts/starknet/ExecutionStrategies/ZodiacRelayer.cairo
@@ -7,27 +7,26 @@ from starkware.starknet.common.messages import send_message_to_l1
 
 @external
 func execute{syscall_ptr : felt*}(
-    proposal_outcome : felt,
-    execution_hash : Uint256,
-    execution_params_len : felt,
-    execution_params : felt*,
+    proposal_outcome : felt, execution_params_len : felt, execution_params : felt*
 ):
     alloc_locals
 
     let (caller_address) = get_caller_address()
 
-    # Get the l1 zodiac address
-    with_attr error_message("Invalid execution parameter"):
-        assert execution_params_len = 1
+    # For the zodiac execution strategy, the execution parameters has 3 elements
+    with_attr error_message("Invalid execution param array"):
+        assert execution_params_len = 3
     end
     let l1_zodiac_address = execution_params[0]
+    let execution_hash_low = execution_params[1]
+    let execution_hash_high = execution_params[2]
 
     # Create the payload
     let (message_payload : felt*) = alloc()
     assert message_payload[0] = caller_address
     assert message_payload[1] = proposal_outcome
-    assert message_payload[2] = execution_hash.low
-    assert message_payload[3] = execution_hash.high
+    assert message_payload[2] = execution_hash_low
+    assert message_payload[3] = execution_hash_high
 
     let payload_size = 4
 

--- a/contracts/starknet/Interfaces/IExecutionStrategy.cairo
+++ b/contracts/starknet/Interfaces/IExecutionStrategy.cairo
@@ -5,11 +5,6 @@ from starkware.cairo.common.uint256 import Uint256
 
 @contract_interface
 namespace IExecutionStrategy:
-    func execute(
-        proposal_outcome : felt,
-        execution_hash : Uint256,
-        execution_params_len : felt,
-        execution_params : felt*,
-    ):
+    func execute(proposal_outcome : felt, execution_params_len : felt, execution_params : felt*):
     end
 end

--- a/contracts/starknet/Space.cairo
+++ b/contracts/starknet/Space.cairo
@@ -748,7 +748,6 @@ end
 @external
 func propose{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
     proposer_address : Address,
-    execution_hash : Uint256,
     metadata_uri_len : felt,
     metadata_uri : felt*,
     executor : felt,
@@ -806,20 +805,20 @@ func propose{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr :
     end
 
     # Hash the execution params
-    let (hash) = hash_array(execution_params_len, execution_params)
+    # Storing arrays inside a struct is impossible so instead we just store a hash and then reconstruct the array in finalize_proposal
+    let (execution_hash) = hash_array(execution_params_len, execution_params)
 
     let (_quorum) = quorum_store.read()
 
     # Create the proposal and its proposal id
     let proposal = Proposal(
-        execution_hash,
         _quorum,
         snapshot_timestamp,
         start_timestamp,
         min_end_timestamp,
         max_end_timestamp,
-        hash,
         executor,
+        execution_hash,
     )
 
     let (proposal_id) = next_proposal_nonce_store.read()
@@ -871,10 +870,10 @@ func finalize_proposal{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_c
         assert_le(proposal.min_end_timestamp, current_timestamp)
     end
 
-    # Make sure execution params match the stored hash
+    # Make sure execution params match the ones sent at proposal creation by checking that the hashes match
     let (recovered_hash) = hash_array(execution_params_len, execution_params)
     with_attr error_message("Invalid execution parameters"):
-        assert recovered_hash = proposal.execution_params_hash
+        assert recovered_hash = proposal.execution_hash
     end
 
     # Count votes for
@@ -922,7 +921,6 @@ func finalize_proposal{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_c
     IExecutionStrategy.execute(
         contract_address=proposal.executor,
         proposal_outcome=proposal_outcome,
-        execution_hash=proposal.execution_hash,
         execution_params_len=execution_params_len,
         execution_params=execution_params,
     )
@@ -965,7 +963,6 @@ func cancel_proposal{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_che
     IExecutionStrategy.execute(
         contract_address=proposal.executor,
         proposal_outcome=proposal_outcome,
-        execution_hash=proposal.execution_hash,
         execution_params_len=execution_params_len,
         execution_params=execution_params,
     )

--- a/contracts/starknet/Space.cairo
+++ b/contracts/starknet/Space.cairo
@@ -234,6 +234,7 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     unchecked_add_authenticators(_authenticators_len, _authenticators)
     unchecked_add_executors(_executors_len, _executors)
 
+    # The first proposal in a space will have a proposal ID of 1.
     next_proposal_nonce_store.write(1)
 
     space_created.emit(

--- a/contracts/starknet/lib/proposal.cairo
+++ b/contracts/starknet/lib/proposal.cairo
@@ -1,12 +1,11 @@
 from starkware.cairo.common.uint256 import Uint256
 
 struct Proposal:
-    member execution_hash : Uint256
     member quorum : Uint256
     member snapshot_timestamp : felt
     member start_timestamp : felt
     member min_end_timestamp : felt
     member max_end_timestamp : felt
-    member execution_params_hash : felt
     member executor : felt
+    member execution_hash : felt
 end

--- a/deployments/goerli2.json
+++ b/deployments/goerli2.json
@@ -1,0 +1,34 @@
+{
+    "space": {
+        "address": "0x794d325db8a7e60b1671c7280e697260433af01b017235f9ce092e775dacdf8",
+        "authenticators": {
+            "StarkTx": "0x6b468438f5692139f657f42ba54ac89a8944eda73088173489fe3cae08addfb",
+            "Vanilla": "0x406c761687627770ffe3913904215c4652bd9f06b72046b301ce4aee093329f"
+        },
+        "controller": "0x0070d911463b2cb48de8bfec826483631cdc492a6c5798917651297769fc9d68",
+        "executionStrategies": {
+            "Starknet": "0x76c99e71d34564a754c3a4bba02ff7c45c6e4264afce540827085348b4dc6aa",
+            "Vanilla": "0x4194fa1be0fce6f70e8b8d3e2b4730467f80637878f9e5111db0cefefb0da72",
+            "zodiacRelayer": "0xcf166a5c95d1d49109d058fc4a89b6a5ae6e2abc4f487f24a5d9fb6ee947b0"
+        },
+        "maxVotingDuration": "0x7d0",
+        "minVotingDuration": "0x0",
+        "name": "Test space",
+        "proposalThreshold": "0x1",
+        "quorum": "0x1",
+        "votingStrategies": {
+            "SingleSlotProof": {
+                "address": "0x275b259a35fe0be03d9f211aefcc04c5f5e3fec89e87b8681f84bae87535b51",
+                "parameters": [
+                    "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+                    "0x0"
+                ]
+            },
+            "Vanilla": {
+                "address": "0x244949da6544e5b8281e4bb2b06107fa0cbfd7169d89762e4f960379eb6b3b2",
+                "parameters": [
+                ]
+            }
+        }
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-https://github.com/starkware-libs/cairo-lang/releases/download/v0.8.2/cairo-lang-0.8.2.zip
+https://github.com/starkware-libs/cairo-lang/releases/download/v0.9.0/cairo-lang-0.9.0.zip
 openzeppelin-cairo-contracts

--- a/scripts/deployTestSpace.ts
+++ b/scripts/deployTestSpace.ts
@@ -46,6 +46,13 @@ async function main() {
       )
       .toString('ascii')
   );
+  const compiledStarknetExecutionStrategy = json.parse(
+    fs
+      .readFileSync(
+        './starknet-artifacts/contracts/starknet/ExecutionStrategies/Starknet.cairo/Starknet.json'
+      )
+      .toString('ascii')
+  );
   const compiledSpace = json.parse(
     fs
       .readFileSync('./starknet-artifacts/contracts/starknet/Space.cairo/Space.json')
@@ -59,6 +66,7 @@ async function main() {
     defaultProvider.deployContract({ contract: compiledSingleSlotProofVotingStrategy }),
     defaultProvider.deployContract({ contract: compiledVanillaExecutionStrategy }),
     defaultProvider.deployContract({ contract: compiledZodiacRelayerExecutionStrategy }),
+    defaultProvider.deployContract({ contract: compiledStarknetExecutionStrategy }),
   ];
   const responses = await Promise.all(deployTxs);
   const vanillaAuthenticatorAddress = responses[0].address!;
@@ -67,7 +75,7 @@ async function main() {
   const singleSlotProofVotingStrategyAddress = responses[3].address!;
   const vanillaExecutionStrategyAddress = responses[4].address!;
   const zodiacRelayerExecutionStrategyAddress = responses[5].address!;
-
+  const starknetExecutionStrategyAddress = responses[6].address!;
   console.log(responses);
 
   const votingDelay = BigInt(0);
@@ -89,6 +97,7 @@ async function main() {
   const executors: bigint[] = [
     BigInt(vanillaExecutionStrategyAddress),
     BigInt(zodiacRelayerExecutionStrategyAddress),
+    BigInt(starknetExecutionStrategyAddress),
   ];
   const quorum: SplitUint256 = SplitUint256.fromUint(BigInt(1)); //  Quorum of one for the vanilla test
   const proposalThreshold: SplitUint256 = SplitUint256.fromUint(BigInt(1)); // Proposal threshold of 1 for the vanilla test
@@ -146,10 +155,12 @@ async function main() {
       executionStrategies: {
         Vanilla: vanillaExecutionStrategyAddress,
         zodiacRelayer: zodiacRelayerExecutionStrategyAddress,
+        Starknet: starknetExecutionStrategyAddress,
       },
     },
   };
-  fs.writeFileSync('./deployments/goerli1.json', JSON.stringify(deployments));
+
+  fs.writeFileSync('./deployments/goerli2.json', JSON.stringify(deployments));
 }
 
 main()

--- a/test/crosschain/EthTxAuth.test.ts
+++ b/test/crosschain/EthTxAuth.test.ts
@@ -65,7 +65,6 @@ describe('L1 interaction with Snapshot X', function () {
       starknetCommit,
     } = await ethTxAuthSetup());
 
-    ({ executionHash } = createExecutionHash(ethers.Wallet.createRandom().address, tx1, tx2));
     metadataUri = strToShortStringArr(
       'Hello and welcome to Snapshot X. This is the future of governance.'
     );
@@ -77,7 +76,6 @@ describe('L1 interaction with Snapshot X', function () {
     executionParams = [];
     proposeCalldata = getProposeCalldata(
       proposerEthAddress,
-      executionHash,
       metadataUri,
       executionStrategy,
       usedVotingStrategies,

--- a/test/crosschain/EthTxAuth.test.ts
+++ b/test/crosschain/EthTxAuth.test.ts
@@ -4,27 +4,9 @@ import { Contract } from 'ethers';
 import { starknet, network, ethers } from 'hardhat';
 import { StarknetContract, Account, HttpNetworkConfig } from 'hardhat/types';
 import { strToShortStringArr } from '@snapshot-labs/sx';
-import { createExecutionHash, getCommit, getProposeCalldata } from '../shared/helpers';
+import { getCommit, getProposeCalldata } from '../shared/helpers';
 import { ethTxAuthSetup } from '../shared/setup';
 import { PROPOSE_SELECTOR } from '../shared/constants';
-
-// Dummy tx
-const tx1 = {
-  to: ethers.Wallet.createRandom().address,
-  value: 0,
-  data: '0x11',
-  operation: 0,
-  nonce: 0,
-};
-
-// Dummy tx 2
-const tx2 = {
-  to: ethers.Wallet.createRandom().address,
-  value: 0,
-  data: '0x22',
-  operation: 0,
-  nonce: 0,
-};
 
 describe('L1 interaction with Snapshot X', function () {
   this.timeout(5000000);
@@ -42,7 +24,6 @@ describe('L1 interaction with Snapshot X', function () {
 
   // Proposal creation parameters
   let spaceAddress: bigint;
-  let executionHash: string;
   let metadataUri: bigint[];
   let proposerEthAddress: string;
   let usedVotingStrategies: bigint[];

--- a/test/crosschain/ZodiacExecution.test.ts
+++ b/test/crosschain/ZodiacExecution.test.ts
@@ -94,11 +94,14 @@ describe('Create proposal, cast vote, and send execution to l1', function () {
     usedVotingStrategies1 = [BigInt(vanillaVotingStrategy.address)];
     userVotingParamsAll1 = [[]];
     executionStrategy = BigInt(zodiacRelayer.address);
-    executionParams = [BigInt(zodiacModule.address)];
+    executionParams = [
+      BigInt(zodiacModule.address),
+      SplitUint256.fromHex(executionHash).low,
+      SplitUint256.fromHex(executionHash).high,
+    ];
 
     proposeCalldata = getProposeCalldata(
       proposerEthAddress,
-      executionHash,
       metadataUri,
       executionStrategy,
       usedVotingStrategies1,

--- a/test/shared/constants.ts
+++ b/test/shared/constants.ts
@@ -3,3 +3,4 @@ const { getSelectorFromName } = hash;
 
 export const PROPOSE_SELECTOR = BigInt(getSelectorFromName('propose'));
 export const VOTE_SELECTOR = BigInt(getSelectorFromName('vote'));
+export const AUTHENTICATE_SELECTOR = BigInt(getSelectorFromName('authenticate'));

--- a/test/shared/helpers.ts
+++ b/test/shared/helpers.ts
@@ -189,47 +189,6 @@ export function createStarknetExecutionParams(callArray: Call[]): bigint[] {
   if (!callArray || callArray.length == 0) {
     return [];
   }
-  let executionParams: bigint[] = [];
-  callArray.forEach((call) => {
-    executionParams.push(call.to);
-    executionParams.push(call.functionSelector);
-    executionParams.push(BigInt(call.calldata.length));
-    executionParams = executionParams.concat(call.calldata);
-  });
-
-  // // 1 because we need to count data_offset
-  // // 4 because there are four elements: `to`, `function_selector`, `calldata_len` and `calldata_offset`
-  // const dataOffset = BigInt(1 + callArray.length * 4);
-
-  // const executionParams = [dataOffset];
-  // let calldataIndex = 0;
-
-  // // First, layout the calls
-  // callArray.forEach((call) => {
-  //   const subArr: bigint[] = [
-  //     call.to,
-  //     call.functionSelector,
-  //     BigInt(call.calldata.length),
-  //     BigInt(calldataIndex),
-  //   ];
-  //   calldataIndex += call.calldata.length;
-  //   executionParams.push(...subArr);
-  // });
-
-  // // Then layout the calldata
-  // callArray.forEach((call) => {
-  //   executionParams.push(...call.calldata);
-  // });
-  return executionParams;
-}
-
-/**
- * For more info about the starknetExecutionParams layout, please see `contracts/starknet/execution_strategies/starknet.cairo`.
- */
-export function createStarknetExecutionParams2(callArray: Call[]): bigint[] {
-  if (!callArray || callArray.length == 0) {
-    return [];
-  }
 
   // 1 because we need to count data_offset
   // 4 because there are four elements: `to`, `function_selector`, `calldata_len` and `calldata_offset`

--- a/test/shared/helpers.ts
+++ b/test/shared/helpers.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'hardhat';
-import { SplitUint256, Choice } from './types';
+import { Choice } from './types';
 import { expect } from 'chai';
 import { computeHashOnElements } from 'starknet/dist/utils/hash';
 import { toBN } from 'starknet/dist/utils/number';
@@ -174,4 +174,44 @@ export function getVoteCalldata(
     BigInt(usedVotingStrategyParamsFlat.length),
     ...usedVotingStrategyParamsFlat,
   ];
+}
+
+export interface Call {
+  to: bigint;
+  functionSelector: bigint;
+  calldata: bigint[];
+}
+
+/**
+ * For more info about the starknetExecutionParams layout, please see `contracts/starknet/execution_strategies/starknet.cairo`.
+ */
+export function createStarknetExecutionParams(callArray: Call[]): bigint[] {
+  if (!callArray || callArray.length == 0) {
+    return [];
+  }
+
+  // 1 because we need to count data_offset
+  // 4 because there are four elements: `to`, `function_selector`, `calldata_len` and `calldata_offset`
+  const dataOffset = BigInt(1 + callArray.length * 4);
+
+  const executionParams = [dataOffset];
+  let calldataIndex = 0;
+
+  // First, layout the calls
+  callArray.forEach((call) => {
+    const subArr: bigint[] = [
+      call.to,
+      call.functionSelector,
+      BigInt(call.calldata.length),
+      BigInt(calldataIndex),
+    ];
+    calldataIndex += call.calldata.length;
+    executionParams.push(...subArr);
+  });
+
+  // Then layout the calldata
+  callArray.forEach((call) => {
+    executionParams.push(...call.calldata);
+  });
+  return executionParams;
 }

--- a/test/shared/helpers.ts
+++ b/test/shared/helpers.ts
@@ -189,6 +189,47 @@ export function createStarknetExecutionParams(callArray: Call[]): bigint[] {
   if (!callArray || callArray.length == 0) {
     return [];
   }
+  let executionParams: bigint[] = [];
+  callArray.forEach((call) => {
+    executionParams.push(call.to);
+    executionParams.push(call.functionSelector);
+    executionParams.push(BigInt(call.calldata.length));
+    executionParams = executionParams.concat(call.calldata);
+  });
+
+  // // 1 because we need to count data_offset
+  // // 4 because there are four elements: `to`, `function_selector`, `calldata_len` and `calldata_offset`
+  // const dataOffset = BigInt(1 + callArray.length * 4);
+
+  // const executionParams = [dataOffset];
+  // let calldataIndex = 0;
+
+  // // First, layout the calls
+  // callArray.forEach((call) => {
+  //   const subArr: bigint[] = [
+  //     call.to,
+  //     call.functionSelector,
+  //     BigInt(call.calldata.length),
+  //     BigInt(calldataIndex),
+  //   ];
+  //   calldataIndex += call.calldata.length;
+  //   executionParams.push(...subArr);
+  // });
+
+  // // Then layout the calldata
+  // callArray.forEach((call) => {
+  //   executionParams.push(...call.calldata);
+  // });
+  return executionParams;
+}
+
+/**
+ * For more info about the starknetExecutionParams layout, please see `contracts/starknet/execution_strategies/starknet.cairo`.
+ */
+export function createStarknetExecutionParams2(callArray: Call[]): bigint[] {
+  if (!callArray || callArray.length == 0) {
+    return [];
+  }
 
   // 1 because we need to count data_offset
   // 4 because there are four elements: `to`, `function_selector`, `calldata_len` and `calldata_offset`

--- a/test/shared/helpers.ts
+++ b/test/shared/helpers.ts
@@ -136,19 +136,15 @@ export function flatten2DArray(array2D: bigint[][]): bigint[] {
 
 export function getProposeCalldata(
   proposerEthAddress: string,
-  executionHash: string,
   metadataUri: bigint[],
   executorAddress: bigint,
   usedVotingStrategies: bigint[],
   usedVotingStrategyParams: bigint[][],
   executionParams: bigint[]
 ): bigint[] {
-  const executionHashUint256 = SplitUint256.fromHex(executionHash);
   const usedVotingStrategyParamsFlat = flatten2DArray(usedVotingStrategyParams);
   return [
     BigInt(proposerEthAddress),
-    executionHashUint256.low,
-    executionHashUint256.high,
     BigInt(metadataUri.length),
     ...metadataUri,
     executorAddress,

--- a/test/shared/setup.ts
+++ b/test/shared/setup.ts
@@ -604,7 +604,11 @@ export async function starknetExecutionSetup() {
   const votingStrategyParams: bigint[][] = [[]]; // No params for the vanilla voting strategy
   const votingStrategyParamsFlat: bigint[] = flatten2DArray(votingStrategyParams);
   const authenticators: bigint[] = [BigInt(vanillaAuthenticator.address)];
-  const executors: bigint[] = [BigInt(starknetExecutionStrategy.address)];
+  const executors: bigint[] = [
+    BigInt(starknetExecutionStrategy.address),
+    BigInt(1234),
+    BigInt(4567),
+  ]; // We add dummy executors that get used in the test transactions
   const quorum: SplitUint256 = SplitUint256.fromUint(BigInt(1)); //  Quorum of one for the vanilla test
   const proposalThreshold: SplitUint256 = SplitUint256.fromUint(BigInt(1)); // Proposal threshold of 1 for the vanilla test
 

--- a/test/shared/setup.ts
+++ b/test/shared/setup.ts
@@ -584,7 +584,7 @@ export async function starknetExecutionSetup() {
     './contracts/starknet/Authenticators/Vanilla.cairo'
   );
   const starknetExecutionStrategyFactory = await starknet.getContractFactory(
-    './contracts/starknet/ExecutionStrategies/Vanilla.cairo'
+    './contracts/starknet/ExecutionStrategies/Starknet.cairo'
   );
 
   const deployments = [

--- a/test/shared/setup.ts
+++ b/test/shared/setup.ts
@@ -608,6 +608,7 @@ export async function starknetExecutionSetup() {
     BigInt(starknetExecutionStrategy.address),
     BigInt(1234),
     BigInt(4567),
+    BigInt(456789),
   ]; // We add dummy executors that get used in the test transactions
   const quorum: SplitUint256 = SplitUint256.fromUint(BigInt(1)); //  Quorum of one for the vanilla test
   const proposalThreshold: SplitUint256 = SplitUint256.fromUint(BigInt(1)); // Proposal threshold of 1 for the vanilla test

--- a/test/starknet/ExecutorWhitelist.test.ts
+++ b/test/starknet/ExecutorWhitelist.test.ts
@@ -3,6 +3,7 @@ import { Contract } from 'ethers';
 import { starknet, ethers } from 'hardhat';
 import { strToShortStringArr } from '@snapshot-labs/sx';
 import { zodiacRelayerSetup } from '../shared/setup';
+import { SplitUint256 } from '../shared/types';
 import { getProposeCalldata, bytesToHex } from '../shared/helpers';
 import { StarknetContract, Account } from 'hardhat/types';
 import { PROPOSE_SELECTOR } from '../shared/constants';
@@ -51,7 +52,7 @@ describe('Whitelist testing', () => {
     vanillaExecutionStrategy = await vanillaExecutionStrategyFactory.deploy();
 
     spaceAddress = BigInt(space.address);
-    executionHash = bytesToHex(ethers.utils.randomBytes(32)); // Random 32 byte hash
+
     metadataUri = strToShortStringArr(
       'Hello and welcome to Snapshot X. This is the future of governance.'
     );
@@ -60,10 +61,14 @@ describe('Whitelist testing', () => {
     usedVotingStrategies1 = [BigInt(vanillaVotingStrategy.address)];
     userVotingParamsAll1 = [[]];
     executionStrategy1 = BigInt(zodiacRelayer.address);
-    executionParams1 = [BigInt(zodiacModule.address)];
+    executionHash = bytesToHex(ethers.utils.randomBytes(32)); // Random 32 byte hash
+    executionParams1 = [
+      BigInt(zodiacModule.address),
+      SplitUint256.fromHex(executionHash).low,
+      SplitUint256.fromHex(executionHash).high,
+    ];
     proposeCalldata1 = getProposeCalldata(
       proposerEthAddress,
-      executionHash,
       metadataUri,
       executionStrategy1,
       usedVotingStrategies1,
@@ -75,7 +80,6 @@ describe('Whitelist testing', () => {
     executionParams2 = [];
     proposeCalldata2 = getProposeCalldata(
       proposerEthAddress,
-      executionHash,
       metadataUri,
       executionStrategy2,
       usedVotingStrategies1,

--- a/test/starknet/SingleSlotProof.test.ts
+++ b/test/starknet/SingleSlotProof.test.ts
@@ -24,7 +24,6 @@ describe('Single slot proof voting strategy:', () => {
 
   // Proposal creation parameters
   let spaceAddress: bigint;
-  let executionHash: string;
   let metadataUri: bigint[];
   let proposerEthAddress: string;
   let usedVotingStrategies1: bigint[];
@@ -120,8 +119,6 @@ describe('Single slot proof voting strategy:', () => {
         proposal_id: proposalId,
       });
 
-      const _executionHash = SplitUint256.fromObj(proposal_info.proposal.execution_hash).toUint();
-      expect(_executionHash).to.deep.equal(BigInt(executionHash));
       const _for = SplitUint256.fromObj(proposal_info.power_for).toUint();
       expect(_for).to.deep.equal(BigInt(0));
       const against = SplitUint256.fromObj(proposal_info.power_against).toUint();

--- a/test/starknet/SingleSlotProof.test.ts
+++ b/test/starknet/SingleSlotProof.test.ts
@@ -1,11 +1,11 @@
 import fs from 'fs';
 import { expect } from 'chai';
-import { starknet, ethers } from 'hardhat';
+import { starknet } from 'hardhat';
 import { SplitUint256, Choice } from '../shared/types';
 import { ProofInputs } from '../shared/parseRPCData';
 import { singleSlotProofSetup, Fossil } from '../shared/setup';
 import { PROPOSE_SELECTOR, VOTE_SELECTOR } from '../shared/constants';
-import { getProposeCalldata, getVoteCalldata, bytesToHex } from '../shared/helpers';
+import { getProposeCalldata, getVoteCalldata } from '../shared/helpers';
 import { StarknetContract, Account } from 'hardhat/types';
 import { strToShortStringArr } from '@snapshot-labs/sx';
 

--- a/test/starknet/SingleSlotProof.test.ts
+++ b/test/starknet/SingleSlotProof.test.ts
@@ -60,7 +60,6 @@ describe('Single slot proof voting strategy:', () => {
     } = await singleSlotProofSetup(block, proofs));
 
     proposalId = BigInt(1);
-    executionHash = bytesToHex(ethers.utils.randomBytes(32)); // Random 32 byte hash
     metadataUri = strToShortStringArr(
       'Hello and welcome to Snapshot X. This is the future of governance.'
     );
@@ -73,7 +72,6 @@ describe('Single slot proof voting strategy:', () => {
     executionParams = [];
     proposeCalldata = getProposeCalldata(
       proposerEthAddress,
-      executionHash,
       metadataUri,
       executionStrategy,
       usedVotingStrategies1,

--- a/test/starknet/Space.test.ts
+++ b/test/starknet/Space.test.ts
@@ -3,7 +3,7 @@ import { ethers } from 'hardhat';
 import { StarknetContract, Account } from 'hardhat/types';
 import { strToShortStringArr } from '@snapshot-labs/sx';
 import { SplitUint256, Choice } from '../shared/types';
-import { getProposeCalldata, getVoteCalldata, bytesToHex } from '../shared/helpers';
+import { getProposeCalldata, getVoteCalldata } from '../shared/helpers';
 import { vanillaSetup } from '../shared/setup';
 import { PROPOSE_SELECTOR, VOTE_SELECTOR } from '../shared/constants';
 
@@ -17,7 +17,6 @@ describe('Space Testing', () => {
 
   // Proposal creation parameters
   let spaceAddress: bigint;
-  let executionHash: string;
   let metadataUri: bigint[];
   let proposerEthAddress: string;
   let usedVotingStrategies1: bigint[];

--- a/test/starknet/StarkTxAuth.test.ts
+++ b/test/starknet/StarkTxAuth.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
-import { starknet, ethers } from 'hardhat';
+import { starknet } from 'hardhat';
 import { StarknetContract, Account } from 'hardhat/types';
 import { strToShortStringArr } from '@snapshot-labs/sx';
 import { SplitUint256, Choice } from '../shared/types';
-import { getProposeCalldata, getVoteCalldata, bytesToHex } from '../shared/helpers';
+import { getProposeCalldata, getVoteCalldata } from '../shared/helpers';
 import { starkTxAuthSetup } from '../shared/setup';
 import { PROPOSE_SELECTOR, VOTE_SELECTOR } from '../shared/constants';
 
@@ -19,7 +19,6 @@ describe('StarkNet Tx Auth testing', () => {
 
   // Proposal creation parameters
   let spaceAddress: bigint;
-  let executionHash: string;
   let metadataUri: bigint[];
   let proposerAccount: Account;
   let proposerAddress: string;

--- a/test/starknet/StarkTxAuth.test.ts
+++ b/test/starknet/StarkTxAuth.test.ts
@@ -50,7 +50,6 @@ describe('StarkNet Tx Auth testing', () => {
       vanillaExecutionStrategy,
     } = await starkTxAuthSetup());
 
-    executionHash = bytesToHex(ethers.utils.randomBytes(32)); // Random 32 byte hash
     metadataUri = strToShortStringArr(
       'Hello and welcome to Snapshot X. This is the future of governance.'
     );
@@ -62,7 +61,6 @@ describe('StarkNet Tx Auth testing', () => {
     executionParams = [];
     proposeCalldata = getProposeCalldata(
       proposerAddress,
-      executionHash,
       metadataUri,
       executionStrategy,
       usedVotingStrategies1,
@@ -113,9 +111,6 @@ describe('StarkNet Tx Auth testing', () => {
       const { proposal_info } = await space.call('get_proposal_info', {
         proposal_id: proposalId,
       });
-
-      const _executionHash = SplitUint256.fromObj(proposal_info.proposal.execution_hash).toUint();
-      expect(_executionHash).to.deep.equal(BigInt(executionHash));
 
       const _for = SplitUint256.fromObj(proposal_info.power_for).toUint();
       expect(_for).to.deep.equal(BigInt(0));

--- a/test/starknet/StarknetExecution.test.ts
+++ b/test/starknet/StarknetExecution.test.ts
@@ -58,7 +58,7 @@ describe('Space Testing', () => {
     const callCalldata1 = getProposeCalldata(
       proposerEthAddress,
       metadataUri,
-      executionStrategy,
+      BigInt(1234),
       usedVotingStrategies1,
       userVotingParamsAll1,
       []
@@ -66,7 +66,7 @@ describe('Space Testing', () => {
     const callCalldata2 = getProposeCalldata(
       proposerEthAddress,
       metadataUri,
-      executionStrategy,
+      BigInt(4567),
       usedVotingStrategies1,
       userVotingParamsAll1,
       []
@@ -82,7 +82,7 @@ describe('Space Testing', () => {
       calldata: [spaceAddress, PROPOSE_SELECTOR, BigInt(callCalldata2.length), ...callCalldata2],
     };
     executionParams = createStarknetExecutionParams([call1, call2]);
-
+    console.log(executionParams);
     proposeCalldata = getProposeCalldata(
       proposerEthAddress,
       metadataUri,
@@ -158,13 +158,13 @@ describe('Space Testing', () => {
       });
       // We can check that the proposal was successfully created by checking the execution strategy
       // as it will be zero if the new proposal was not created
-      expect(proposal_info.proposal.executor).to.deep.equal(executionStrategy);
+      expect(proposal_info.proposal.executor).to.deep.equal(BigInt(1234));
 
       // Same for second dummy proposal
       ({ proposal_info } = await space.call('get_proposal_info', {
         proposal_id: 3,
       }));
-      expect(proposal_info.proposal.executor).to.deep.equal(executionStrategy);
+      expect(proposal_info.proposal.executor).to.deep.equal(BigInt(4567));
     }
   }).timeout(6000000);
 });

--- a/test/starknet/StarknetExecution.test.ts
+++ b/test/starknet/StarknetExecution.test.ts
@@ -71,6 +71,14 @@ describe('Space Testing', () => {
       userVotingParamsAll1,
       []
     );
+    const callCalldata3 = getProposeCalldata(
+      proposerEthAddress,
+      metadataUri,
+      BigInt(456789),
+      usedVotingStrategies1,
+      userVotingParamsAll1,
+      []
+    );
     const call1: Call = {
       to: BigInt(vanillaAuthenticator.address),
       functionSelector: AUTHENTICATE_SELECTOR,
@@ -81,8 +89,13 @@ describe('Space Testing', () => {
       functionSelector: AUTHENTICATE_SELECTOR,
       calldata: [spaceAddress, PROPOSE_SELECTOR, BigInt(callCalldata2.length), ...callCalldata2],
     };
-    executionParams = createStarknetExecutionParams([call1, call2]);
-    console.log(executionParams);
+    const call3: Call = {
+      to: BigInt(vanillaAuthenticator.address),
+      functionSelector: AUTHENTICATE_SELECTOR,
+      calldata: [spaceAddress, PROPOSE_SELECTOR, BigInt(callCalldata3.length), ...callCalldata3],
+    };
+    executionParams = createStarknetExecutionParams([call1, call2, call3]);
+
     proposeCalldata = getProposeCalldata(
       proposerEthAddress,
       metadataUri,
@@ -165,6 +178,11 @@ describe('Space Testing', () => {
         proposal_id: 3,
       }));
       expect(proposal_info.proposal.executor).to.deep.equal(BigInt(4567));
+
+      ({ proposal_info } = await space.call('get_proposal_info', {
+        proposal_id: 4,
+      }));
+      expect(proposal_info.proposal.executor).to.deep.equal(BigInt(456789));
     }
   }).timeout(6000000);
 });

--- a/test/starknet/StarknetExecution.test.ts
+++ b/test/starknet/StarknetExecution.test.ts
@@ -4,7 +4,7 @@ import { StarknetContract, Account } from 'hardhat/types';
 import { strToShortStringArr } from '@snapshot-labs/sx';
 import { SplitUint256, Choice } from '../shared/types';
 import { getProposeCalldata, getVoteCalldata, bytesToHex } from '../shared/helpers';
-import { vanillaSetup } from '../shared/setup';
+import { starknetExecutionSetup } from '../shared/setup';
 import { PROPOSE_SELECTOR, VOTE_SELECTOR } from '../shared/constants';
 
 describe('Space Testing', () => {
@@ -13,7 +13,7 @@ describe('Space Testing', () => {
   let controller: Account;
   let vanillaAuthenticator: StarknetContract;
   let vanillaVotingStrategy: StarknetContract;
-  let vanillaExecutionStrategy: StarknetContract;
+  let starknetExecutionStrategy: StarknetContract;
 
   // Proposal creation parameters
   let spaceAddress: bigint;
@@ -37,9 +37,10 @@ describe('Space Testing', () => {
   before(async function () {
     this.timeout(800000);
 
-    ({ space, controller, vanillaAuthenticator, vanillaVotingStrategy, vanillaExecutionStrategy } =
-      await vanillaSetup());
+    ({ space, controller, vanillaAuthenticator, vanillaVotingStrategy, starknetExecutionStrategy } =
+      await starknetExecutionSetup());
 
+    executionHash = bytesToHex(ethers.utils.randomBytes(32)); // Random 32 byte hash
     metadataUri = strToShortStringArr(
       'Hello and welcome to Snapshot X. This is the future of governance.'
     );
@@ -85,6 +86,8 @@ describe('Space Testing', () => {
         proposal_id: proposalId,
       });
 
+      const _executionHash = SplitUint256.fromObj(proposal_info.proposal.execution_hash).toUint();
+      expect(_executionHash).to.deep.equal(BigInt(executionHash));
       const _for = SplitUint256.fromObj(proposal_info.power_for).toUint();
       expect(_for).to.deep.equal(BigInt(0));
       const against = SplitUint256.fromObj(proposal_info.power_against).toUint();


### PR DESCRIPTION
Continuation of Scotts work on https://github.com/snapshot-labs/sx-core/pull/148. 

We generalised the execution for SX by removing the execution hash (that was a uint256 stored for each proposal). Now there is just the `execution_params` array that can arbitrarily contain execution hashes or simply raw tx data. For each proposal, we store the pedersen hash of this array. It is up to the execution strategy to decode this data and perform the necessary execution. 

New PR as there was lots of structural changes to the repo since the first one so decided it was easier to start again and copy code across. 