### PR TITLE
Improved array storage handling in Space contract

### DIFF
--- a/contracts/starknet/Space.cairo
+++ b/contracts/starknet/Space.cairo
@@ -296,7 +296,7 @@ func unchecked_add_voting_strategies{
         # Extract voting params for the voting strategy
         let (params_len, params) = get_sub_array(params_all, index)
 
-        # We store the length of the voting strategy params array in the first parameter
+        # We store the length of the voting strategy params array at index zero
         voting_strategy_params_store.write(to_add[0], 0, params_len)
 
         # The following elements are the actual params
@@ -316,7 +316,7 @@ func unchecked_add_voting_strategy_params{
     else:
         # Store voting parameter
         voting_strategy_params_store.write(to_add, index, params[0])
-        # Recurse
+
         unchecked_add_voting_strategy_params(to_add, params_len - 1, &params[1], index + 1)
         return ()
     end
@@ -330,11 +330,13 @@ func unchecked_remove_voting_strategies{
     else:
         voting_strategies_store.write(to_remove[0], 0)
 
+        # The length of the voting strategy params is stored at index zero
         let (params_len) = voting_strategy_params_store.read(to_remove[0], 0)
 
-        unchecked_remove_voting_strategy_params(to_remove[0], params_len, 1)
-
         voting_strategy_params_store.write(to_remove[0], 0, 0)
+
+        # Removing voting strategy params
+        unchecked_remove_voting_strategy_params(to_remove[0], params_len, 1)
 
         unchecked_remove_voting_strategies(to_remove_len - 1, &to_remove[1])
         return ()
@@ -354,7 +356,7 @@ func unchecked_remove_voting_strategy_params{
     end
     # Remove voting parameter
     voting_strategy_params_store.write(to_remove, index, 0)
-    # Recurse
+
     unchecked_remove_voting_strategy_params(to_remove, params_len, index + 1)
     return ()
 end

--- a/contracts/starknet/VotingStrategies/SingleSlotProof.cairo
+++ b/contracts/starknet/VotingStrategies/SingleSlotProof.cairo
@@ -75,11 +75,7 @@ func get_voting_power{
     # contract address where the desired slot resides, and the section element is the index of the slot in that contract.
     assert params_len = 2
     let contract_address = params[0]
-
-    # In the current implementation, we cant store arrays with a zero as the last element because the read function would just treat
-    # the array is 1 element shorter. Hence, we offset the slot_index by 1 so that it is never zero.
-    # Probably worth changing our array handling so this is not necessary.
-    let slot_index = params[1] - 1
+    let slot_index = params[1]
 
     # Checking slot proof is for the correct slot
     let (valid_slot) = get_slot_key(slot_index, voter_address.value)

--- a/test/shared/setup.ts
+++ b/test/shared/setup.ts
@@ -368,7 +368,7 @@ export async function singleSlotProofSetup(block: any, proofs: any) {
   const minVotingDuration = BigInt(0);
   const maxVotingDuration = BigInt(2000);
   const votingStrategies: bigint[] = [BigInt(singleSlotProofStrategy.address)];
-  const votingStrategyParams: bigint[][] = [[proofInputs.ethAddressFelt, BigInt(1)]];
+  const votingStrategyParams: bigint[][] = [[proofInputs.ethAddressFelt, BigInt(0)]]; // For the aave erc20 contract, the balances mapping has a storage index of 0
   const votingStrategyParamsFlat: bigint[] = flatten2DArray(votingStrategyParams);
   const authenticators: bigint[] = [BigInt(vanillaAuthenticator.address)];
   const executors: bigint[] = [BigInt(vanillaExecutionStrategy.address)];

--- a/test/starknet/ControllerActions.test.ts
+++ b/test/starknet/ControllerActions.test.ts
@@ -2,39 +2,50 @@ import { expect } from 'chai';
 import { starknet } from 'hardhat';
 import { vanillaSetup } from '../shared/setup';
 import { StarknetContract, Account } from 'hardhat/types';
+import { flatten2DArray } from '../shared/helpers';
 
-describe('Controller', () => {
+describe('Controller Actions', () => {
   let space: StarknetContract;
   let controller: Account;
+  let user: Account;
 
   before(async function () {
     this.timeout(800000);
-
     ({ space, controller } = await vanillaSetup());
+    user = await starknet.deployAccount('OpenZeppelin');
   });
 
-  it('Should be able to update controller if properly called', async () => {
-    const newController = await starknet.deployAccount('OpenZeppelin');
-
+  it('The controller can update the controller', async () => {
     await controller.invoke(space, 'update_controller', {
-      new_controller: newController.starknetContract.address,
+      new_controller: user.starknetContract.address,
     });
 
     // Now updating again with the new controller
-    await newController.invoke(space, 'update_controller', {
+    await user.invoke(space, 'update_controller', {
       new_controller: controller.starknetContract.address,
     });
   }).timeout(600000);
 
-  it('Should not be able to update controller if not properly called', async () => {
-    const fakeController = await starknet.deployAccount('OpenZeppelin');
-
+  it('Other accounts cannot update the controller', async () => {
     try {
-      await fakeController.invoke(space, 'update_controller', {
-        new_controller: fakeController.starknetContract.address,
+      await user.invoke(space, 'update_controller', {
+        new_controller: user.starknetContract.address,
       });
     } catch (error: any) {
       expect(error.message).to.contain('Ownable: caller is not the owner');
     }
+  }).timeout(600000);
+
+  it('The controller can add and remove voting strategies', async () => {
+    const votingStrategies: bigint[] = [BigInt(1234), BigInt(4567)];
+    const votingStrategyParams: bigint[][] = [[BigInt(1), BigInt(2), BigInt(0)], []];
+    const votingStrategyParamsFlat: bigint[] = flatten2DArray(votingStrategyParams);
+    await controller.invoke(space, 'add_voting_strategies', {
+      to_add: votingStrategies,
+      params_flat: votingStrategyParamsFlat,
+    });
+    await controller.invoke(space, 'remove_voting_strategies', {
+      to_remove: votingStrategies,
+    });
   }).timeout(600000);
 });


### PR DESCRIPTION
In this PR we modify how voting parameter arrays are stored in the space contract. Now, the first parameter of the array is the length of the array and then the following parameters are the elements.

This now enables us to remove the voting parameter array associated with a voting strategy when a voting strategy is removed, which we add in this PR.

This closes https://github.com/snapshot-labs/sx-core/issues/188