### PR TITLE
Fix eth sig failure

### DIFF
--- a/contracts/starknet/Authenticators/EthSig.cairo
+++ b/contracts/starknet/Authenticators/EthSig.cairo
@@ -227,7 +227,6 @@ func authenticate_proposal{
 
     # Space address
     let (space) = FeltUtils.felt_to_uint256(target)
-    let (padded_space) = pad_right(space)
 
     # Proposer address
     let (proposer_address_u256) = FeltUtils.felt_to_uint256(proposer_address)
@@ -244,7 +243,6 @@ func authenticate_proposal{
     # Executor
     let executor = calldata[3 + metadata_uri_len]
     let (executor_u256) = FeltUtils.felt_to_uint256(executor)
-    let (padded_executor) = pad_right(executor_u256)
 
     # Used voting strategies
     let used_voting_strats_len = calldata[4 + metadata_uri_len]
@@ -267,10 +265,10 @@ func authenticate_proposal{
     let (data : Uint256*) = alloc()
 
     assert data[0] = Uint256(PROPOSAL_HASH_LOW, PROPOSAL_HASH_HIGH)
-    assert data[1] = padded_space
+    assert data[1] = space
     assert data[2] = padded_proposer_address
     assert data[3] = metadata_uri_hash
-    assert data[4] = padded_executor
+    assert data[4] = executor_u256
     assert data[5] = execution_hash
     assert data[6] = used_voting_strategies_hash
     assert data[7] = user_voting_strategy_params_flat_hash

--- a/contracts/starknet/Authenticators/EthSig.cairo
+++ b/contracts/starknet/Authenticators/EthSig.cairo
@@ -225,7 +225,8 @@ func authenticate_proposal{
     let (local keccak_ptr : felt*) = alloc()
     let keccak_ptr_start = keccak_ptr
 
-    # Space address
+    # We don't need to pad because calling `.address` with starknet.js
+    # already left pads the address with 0s
     let (space) = FeltUtils.felt_to_uint256(target)
 
     # Proposer address
@@ -331,8 +332,9 @@ func authenticate_vote{
         assert already_used = 0
     end
 
+    # We don't need to pad because calling `.address` with starknet.js
+    # already left pads the address with 0s
     let (space) = FeltUtils.felt_to_uint256(target)
-    let (padded_space) = pad_right(space)
 
     let (voter_address_u256) = FeltUtils.felt_to_uint256(voter_address)
     let (padded_voter_address) = pad_right(voter_address_u256)
@@ -355,7 +357,7 @@ func authenticate_vote{
     # Now construct the data hash (hashStruct)
     let (data : Uint256*) = alloc()
     assert data[0] = Uint256(VOTE_HASH_LOW, VOTE_HASH_HIGH)
-    assert data[1] = padded_space
+    assert data[1] = space
     assert data[2] = padded_voter_address
     assert data[3] = proposal_id
     assert data[4] = choice

--- a/contracts/starknet/lib/hash_array.cairo
+++ b/contracts/starknet/lib/hash_array.cairo
@@ -7,12 +7,13 @@ namespace HashArray:
     # Dev note: starkware.py and starknet.js methods for hashing an array append the length of the array to the end before hashing.
     # This is why we replicate that here.
     func hash_array{pedersen_ptr : HashBuiltin*}(array_len : felt, array : felt*) -> (hash : felt):
-        # Appending the length of the array to itself as the offchain version of the hash works this way
-        assert array[array_len] = array_len
         let (hash_state_ptr) = hash_init()
-        let (hash_state_ptr) = hash_update{hash_ptr=pedersen_ptr}(
-            hash_state_ptr, array, array_len + 1
-        )
+        let (hash_state_ptr) = hash_update{hash_ptr=pedersen_ptr}(hash_state_ptr, array, array_len)
+
+        let (__fp__, _) = get_fp_and_pc()
+
+        # Appending the length of the array to itself as the offchain version of the hash works this way
+        let (hash_state_ptr) = hash_update{hash_ptr=pedersen_ptr}(hash_state_ptr, &array_len, 1)
         return (hash_state_ptr.current_hash)
     end
 end

--- a/test/shared/types.ts
+++ b/test/shared/types.ts
@@ -43,7 +43,7 @@ export interface Vote {
   space: string;
   voterAddress: string;
   proposal: string;
-  choice: number;
+  choice: string;
   usedVotingStrategiesHash: string;
   userVotingStrategyParamsFlatHash: string;
   salt: string;

--- a/test/shared/types.ts
+++ b/test/shared/types.ts
@@ -43,7 +43,7 @@ export interface Vote {
   space: string;
   voterAddress: string;
   proposal: string;
-  choice: string;
+  choice: number;
   usedVotingStrategiesHash: string;
   userVotingStrategyParamsFlatHash: string;
   salt: string;

--- a/test/starknet/EthereumSigAuth.test.ts
+++ b/test/starknet/EthereumSigAuth.test.ts
@@ -246,7 +246,7 @@ describe('Ethereum Sig Auth testing', () => {
         space: spaceStr,
         voterAddress: voterEthAddressPadded,
         proposal: BigInt(proposalId).toString(16),
-        choice: utils.choice.Choice.FOR.toString(16),
+        choice: utils.choice.Choice.FOR,
         usedVotingStrategiesHash: usedVotingStrategiesHashPadded2,
         userVotingStrategyParamsFlatHash: userVotingStrategyParamsFlatHashPadded2,
         salt: voteSalt.toHex(),

--- a/test/starknet/EthereumSigAuth.test.ts
+++ b/test/starknet/EthereumSigAuth.test.ts
@@ -246,7 +246,7 @@ describe('Ethereum Sig Auth testing', () => {
         space: spaceStr,
         voterAddress: voterEthAddressPadded,
         proposal: BigInt(proposalId).toString(16),
-        choice: utils.choice.Choice.FOR,
+        choice: utils.choice.Choice.FOR.toString(16),
         usedVotingStrategiesHash: usedVotingStrategiesHashPadded2,
         userVotingStrategyParamsFlatHash: userVotingStrategyParamsFlatHashPadded2,
         salt: voteSalt.toHex(),

--- a/test/starknet/EthereumSigAuth.test.ts
+++ b/test/starknet/EthereumSigAuth.test.ts
@@ -1,304 +1,304 @@
-// import { expect } from 'chai';
-// import { StarknetContract, Account } from 'hardhat/types';
-// import { ethers } from 'hardhat';
-// import { domain, Propose, proposeTypes, Vote, voteTypes } from '../shared/types';
-// import { computeHashOnElements } from 'starknet/dist/utils/hash';
-// import { utils } from '@snapshot-labs/sx';
-// import { ethereumSigAuthSetup } from '../shared/setup';
-// import { PROPOSE_SELECTOR, VOTE_SELECTOR } from '../shared/constants';
+import { expect } from 'chai';
+import { StarknetContract, Account } from 'hardhat/types';
+import { ethers } from 'hardhat';
+import { domain, Propose, proposeTypes, Vote, voteTypes } from '../shared/types';
+import { computeHashOnElements } from 'starknet/dist/utils/hash';
+import { utils } from '@snapshot-labs/sx';
+import { ethereumSigAuthSetup } from '../shared/setup';
+import { PROPOSE_SELECTOR, VOTE_SELECTOR } from '../shared/constants';
+import { _TypedDataEncoder } from 'ethers/lib/utils';
 
-// export const VITALIK_ADDRESS = BigInt('0xd8da6bf26964af9d7eed9e03e53415d37aa96045');
-// export const AUTHENTICATE_METHOD = 'authenticate';
-// export const PROPOSAL_METHOD = 'propose';
-// export const VOTE_METHOD = 'vote';
-// export const METADATA_URI = 'Hello and welcome to Snapshot X. This is the future of governance.';
+export const VITALIK_ADDRESS = BigInt('0xd8da6bf26964af9d7eed9e03e53415d37aa96045');
+export const AUTHENTICATE_METHOD = 'authenticate';
+export const PROPOSAL_METHOD = 'propose';
+export const VOTE_METHOD = 'vote';
+export const METADATA_URI = 'Hello and welcome to Snapshot X. This is the future of governance.';
 
-// function hexPadRight(s: string) {
-//   // Remove prefix
-//   if (s.startsWith('0x')) {
-//     s = s.substring(2);
-//   }
+function hexPadRight(s: string) {
+  // Remove prefix
+  if (s.startsWith('0x')) {
+    s = s.substring(2);
+  }
 
-//   // Odd length, need to prefix with a 0
-//   if (s.length % 2 != 0) {
-//     s = '0' + s;
-//   }
+  // Odd length, need to prefix with a 0
+  if (s.length % 2 != 0) {
+    s = '0' + s;
+  }
 
-//   const numZeroes = 64 - s.length;
-//   return '0x' + s + '0'.repeat(numZeroes);
-// }
+  const numZeroes = 64 - s.length;
+  return '0x' + s + '0'.repeat(numZeroes);
+}
 
-// describe('Ethereum Sig Auth testing', () => {
-//   // Contracts
-//   let space: StarknetContract;
-//   let controller: Account;
-//   let ethSigAuth: StarknetContract;
-//   let vanillaVotingStrategy: StarknetContract;
-//   let vanillaExecutionStrategy: StarknetContract;
+describe('Ethereum Sig Auth testing', () => {
+  // Contracts
+  let space: StarknetContract;
+  let controller: Account;
+  let ethSigAuth: StarknetContract;
+  let vanillaVotingStrategy: StarknetContract;
+  let vanillaExecutionStrategy: StarknetContract;
 
-//   // Proposal creation parameters
-//   let spaceAddress: string;
-//   let executionHash: string;
-//   let metadataUri: string;
-//   let metadataUriInts: utils.intsSequence.IntsSequence;
-//   let usedVotingStrategies1: string[];
-//   let usedVotingStrategiesHash1: string;
-//   let userVotingParamsAll1: string[][];
-//   let userVotingStrategyParamsFlatHash1: string;
-//   let executionStrategy: string;
-//   let executionParams: string[];
-//   let proposerEthAddress: string;
-//   let proposeCalldata: string[];
+  // Proposal creation parameters
+  let spaceAddress: string;
+  let executionHash: string;
+  let metadataUri: string;
+  let metadataUriInts: utils.intsSequence.IntsSequence;
+  let usedVotingStrategies1: string[];
+  let usedVotingStrategiesHash1: string;
+  let userVotingParamsAll1: string[][];
+  let userVotingStrategyParamsFlatHash1: string;
+  let executionStrategy: string;
+  let executionParams: string[];
+  let proposerEthAddress: string;
+  let proposeCalldata: string[];
 
-//   // Additional parameters for voting
-//   let voterEthAddress: string;
-//   let proposalId: string;
-//   let choice: utils.choice.Choice;
-//   let usedVotingStrategies2: string[];
-//   let usedVotingStrategiesHash2: string;
-//   let userVotingParamsAll2: string[][];
-//   let userVotingStrategyParamsFlatHash2: string;
-//   let voteCalldata: string[];
+  // Additional parameters for voting
+  let voterEthAddress: string;
+  let proposalId: string;
+  let choice: utils.choice.Choice;
+  let usedVotingStrategies2: string[];
+  let usedVotingStrategiesHash2: string;
+  let userVotingParamsAll2: string[][];
+  let userVotingStrategyParamsFlatHash2: string;
+  let voteCalldata: string[];
 
-//   before(async function () {
-//     this.timeout(800000);
-//     const accounts = await ethers.getSigners();
-//     ({ space, controller, ethSigAuth, vanillaVotingStrategy, vanillaExecutionStrategy } =
-//       await ethereumSigAuthSetup());
+  before(async function () {
+    this.timeout(800000);
+    const accounts = await ethers.getSigners();
+    ({ space, controller, ethSigAuth, vanillaVotingStrategy, vanillaExecutionStrategy } =
+      await ethereumSigAuthSetup());
 
-//     metadataUri = 'Hello and welcome to Snapshot X. This is the future of governance.';
-//     metadataUriInts = utils.intsSequence.IntsSequence.LEFromString(metadataUri);
-//     spaceAddress = space.address;
-//     usedVotingStrategies1 = [vanillaVotingStrategy.address];
-//     userVotingParamsAll1 = [[]];
-//     executionStrategy = vanillaExecutionStrategy.address;
+    metadataUri = 'Hello and welcome to Snapshot X. This is the future of governance.';
+    metadataUriInts = utils.intsSequence.IntsSequence.LEFromString(metadataUri);
+    usedVotingStrategies1 = [vanillaVotingStrategy.address];
+    userVotingParamsAll1 = [[]];
+    executionStrategy = vanillaExecutionStrategy.address;
 
-//     executionParams = ['0x01']; // Random params
-//     executionHash = computeHashOnElements(executionParams);
-//     usedVotingStrategiesHash1 = computeHashOnElements(usedVotingStrategies1);
-//     const userVotingStrategyParamsFlat1 = utils.encoding.flatten2DArray(userVotingParamsAll1);
-//     userVotingStrategyParamsFlatHash1 = computeHashOnElements(userVotingStrategyParamsFlat1);
+    executionParams = ['0x01']; // Random params
+    executionHash = computeHashOnElements(executionParams);
+    usedVotingStrategiesHash1 = computeHashOnElements(usedVotingStrategies1);
+    const userVotingStrategyParamsFlat1 = utils.encoding.flatten2DArray(userVotingParamsAll1);
+    userVotingStrategyParamsFlatHash1 = computeHashOnElements(userVotingStrategyParamsFlat1);
 
-//     proposerEthAddress = accounts[0].address;
-//     proposeCalldata = utils.encoding.getProposeCalldata(
-//       proposerEthAddress,
-//       metadataUriInts,
-//       executionStrategy,
-//       usedVotingStrategies1,
-//       userVotingParamsAll1,
-//       executionParams
-//     );
+    proposerEthAddress = accounts[0].address;
+    proposeCalldata = utils.encoding.getProposeCalldata(
+      proposerEthAddress,
+      metadataUriInts,
+      executionStrategy,
+      usedVotingStrategies1,
+      userVotingParamsAll1,
+      executionParams
+    );
 
-//     voterEthAddress = accounts[0].address;
-//     proposalId = '0x1';
-//     choice = utils.choice.Choice.FOR;
-//     usedVotingStrategies2 = [vanillaVotingStrategy.address];
-//     userVotingParamsAll2 = [[]];
-//     usedVotingStrategiesHash2 = computeHashOnElements(usedVotingStrategies2);
-//     const userVotingStrategyParamsFlat2 = utils.encoding.flatten2DArray(userVotingParamsAll2);
-//     userVotingStrategyParamsFlatHash2 = computeHashOnElements(userVotingStrategyParamsFlat2);
-//     voteCalldata = utils.encoding.getVoteCalldata(
-//       voterEthAddress,
-//       proposalId,
-//       choice,
-//       usedVotingStrategies2,
-//       userVotingParamsAll2
-//     );
-//   });
+    voterEthAddress = accounts[0].address;
+    proposalId = '0x1';
+    choice = utils.choice.Choice.FOR;
+    usedVotingStrategies2 = [vanillaVotingStrategy.address];
+    userVotingParamsAll2 = [[]];
+    usedVotingStrategiesHash2 = computeHashOnElements(usedVotingStrategies2);
+    const userVotingStrategyParamsFlat2 = utils.encoding.flatten2DArray(userVotingParamsAll2);
+    userVotingStrategyParamsFlatHash2 = computeHashOnElements(userVotingStrategyParamsFlat2);
+    voteCalldata = utils.encoding.getVoteCalldata(
+      voterEthAddress,
+      proposalId,
+      choice,
+      usedVotingStrategies2,
+      userVotingParamsAll2
+    );
+  });
 
-//   it('Should not authenticate an invalid signature', async () => {
-//     try {
-//       const accounts = await ethers.getSigners();
-//       const salt: utils.splitUint256.SplitUint256 = utils.splitUint256.SplitUint256.fromHex('0x1');
-//       const spaceStr = hexPadRight(space.address);
-//       const executionHashPadded = hexPadRight(executionHash);
-//       const usedVotingStrategiesHashPadded1 = hexPadRight(usedVotingStrategiesHash1);
-//       const userVotingStrategyParamsFlatHashPadded1 = hexPadRight(
-//         userVotingStrategyParamsFlatHash1
-//       );
-//       const paddedProposerAddress = hexPadRight(proposerEthAddress);
-//       const paddedExecutor = hexPadRight(vanillaExecutionStrategy.address);
-//       const message: Propose = {
-//         space: spaceStr,
-//         proposerAddress: paddedProposerAddress,
-//         metadataUri: METADATA_URI,
-//         executor: paddedExecutor,
-//         executionParamsHash: executionHashPadded,
-//         usedVotingStrategiesHash: usedVotingStrategiesHashPadded1,
-//         userVotingStrategyParamsFlatHash: userVotingStrategyParamsFlatHashPadded1,
-//         salt: salt.toHex(),
-//       };
+  it('Should not authenticate an invalid signature', async () => {
+    try {
+      const accounts = await ethers.getSigners();
+      const salt: utils.splitUint256.SplitUint256 = utils.splitUint256.SplitUint256.fromHex('0x1');
+      const spaceStr = hexPadRight(space.address);
+      const executionHashPadded = hexPadRight(executionHash);
+      const usedVotingStrategiesHashPadded1 = hexPadRight(usedVotingStrategiesHash1);
+      const userVotingStrategyParamsFlatHashPadded1 = hexPadRight(
+        userVotingStrategyParamsFlatHash1
+      );
+      const paddedProposerAddress = hexPadRight(proposerEthAddress);
+      const paddedExecutor = hexPadRight(vanillaExecutionStrategy.address);
+      const message: Propose = {
+        space: spaceStr,
+        proposerAddress: paddedProposerAddress,
+        metadataUri: METADATA_URI,
+        executor: paddedExecutor,
+        executionParamsHash: executionHashPadded,
+        usedVotingStrategiesHash: usedVotingStrategiesHashPadded1,
+        userVotingStrategyParamsFlatHash: userVotingStrategyParamsFlatHashPadded1,
+        salt: salt.toHex(),
+      };
 
-//       const fakeData = [...proposeCalldata];
+      const fakeData = [...proposeCalldata];
 
-//       const sig = await accounts[0]._signTypedData(domain, proposeTypes, message);
-//       const { r, s, v } = utils.encoding.getRSVFromSig(sig);
+      const sig = await accounts[0]._signTypedData(domain, proposeTypes, message);
+      const { r, s, v } = utils.encoding.getRSVFromSig(sig);
 
-//       // Data is signed with accounts[0] but the proposer is accounts[1] so it should fail
-//       fakeData[0] = accounts[1].address;
+      // Data is signed with accounts[0] but the proposer is accounts[1] so it should fail
+      fakeData[0] = accounts[1].address;
 
-//       await controller.invoke(ethSigAuth, 'authenticate', {
-//         r: r,
-//         s: s,
-//         v: v,
-//         salt: salt,
-//         target: spaceAddress,
-//         function_selector: PROPOSE_SELECTOR,
-//         calldata: fakeData,
-//       });
-//       expect(1).to.deep.equal(2);
-//     } catch (err: any) {
-//       expect(err.message).to.contain('Invalid signature.');
-//     }
-//   });
+      await controller.invoke(ethSigAuth, 'authenticate', {
+        r: r,
+        s: s,
+        v: v,
+        salt: salt,
+        target: spaceAddress,
+        function_selector: PROPOSE_SELECTOR,
+        calldata: fakeData,
+      });
+      expect(1).to.deep.equal(2);
+    } catch (err: any) {
+      expect(err.message).to.contain('Invalid signature.');
+    }
+  });
 
-//   it('Should create a proposal and cast a vote', async () => {
-//     // -- Creates the proposal --
-//     {
-//       const accounts = await ethers.getSigners();
-//       const proposalSalt: utils.splitUint256.SplitUint256 =
-//         utils.splitUint256.SplitUint256.fromHex('0x01');
+  it('Should create a proposal and cast a vote', async () => {
+    // -- Creates the proposal --
+    {
+      const accounts = await ethers.getSigners();
+      const proposalSalt: utils.splitUint256.SplitUint256 =
+        utils.splitUint256.SplitUint256.fromHex('0x01');
 
-//       const spaceStr = hexPadRight(space.address);
-//       const executionHashPadded = hexPadRight(executionHash);
-//       const usedVotingStrategiesHashPadded1 = hexPadRight(usedVotingStrategiesHash1);
-//       const userVotingStrategyParamsFlatHashPadded1 = hexPadRight(
-//         userVotingStrategyParamsFlatHash1
-//       );
-//       const paddedProposerAddress = hexPadRight(proposerEthAddress);
-//       const paddedExecutor = hexPadRight(vanillaExecutionStrategy.address);
+      const spaceStr = hexPadRight(space.address);
+      const executionHashPadded = hexPadRight(executionHash);
+      const usedVotingStrategiesHashPadded1 = hexPadRight(usedVotingStrategiesHash1);
+      const userVotingStrategyParamsFlatHashPadded1 = hexPadRight(
+        userVotingStrategyParamsFlatHash1
+      );
+      const paddedProposerAddress = hexPadRight(proposerEthAddress);
+      const paddedExecutor = hexPadRight(executionStrategy);
 
-//       const message: Propose = {
-//         space: spaceStr,
-//         proposerAddress: paddedProposerAddress,
-//         metadataUri: METADATA_URI,
-//         executor: paddedExecutor,
-//         executionParamsHash: executionHashPadded,
-//         usedVotingStrategiesHash: usedVotingStrategiesHashPadded1,
-//         userVotingStrategyParamsFlatHash: userVotingStrategyParamsFlatHashPadded1,
-//         salt: proposalSalt.toHex(),
-//       };
+      const message: Propose = {
+        space: spaceStr,
+        proposerAddress: paddedProposerAddress,
+        metadataUri: METADATA_URI,
+        executor: paddedExecutor,
+        executionParamsHash: executionHashPadded,
+        usedVotingStrategiesHash: usedVotingStrategiesHashPadded1,
+        userVotingStrategyParamsFlatHash: userVotingStrategyParamsFlatHashPadded1,
+        salt: proposalSalt.toHex(),
+      };
 
-//       const sig = await accounts[0]._signTypedData(domain, proposeTypes, message);
+      const sig = await accounts[0]._signTypedData(domain, proposeTypes, message);
 
-//       const { r, s, v } = utils.encoding.getRSVFromSig(sig);
+      const { r, s, v } = utils.encoding.getRSVFromSig(sig);
 
-//       console.log('Creating proposal...');
-//       await controller.invoke(ethSigAuth, 'authenticate', {
-//         r: r,
-//         s: s,
-//         v: v,
-//         salt: proposalSalt,
-//         target: spaceAddress,
-//         function_selector: PROPOSE_SELECTOR,
-//         calldata: proposeCalldata,
-//       });
+      console.log('Creating proposal...');
+      await controller.invoke(ethSigAuth, 'authenticate', {
+        r: r,
+        s: s,
+        v: v,
+        salt: proposalSalt,
+        target: spaceStr,
+        function_selector: PROPOSE_SELECTOR,
+        calldata: proposeCalldata,
+      });
 
-//       console.log('Getting proposal info...');
-//       const { proposal_info } = await space.call('get_proposal_info', {
-//         proposal_id: proposalId,
-//       });
+      console.log('Getting proposal info...');
+      const { proposal_info } = await space.call('get_proposal_info', {
+        proposal_id: proposalId,
+      });
 
-//       // -- Attempts a replay attack on `propose` method --
-//       // Expected to fail
-//       try {
-//         console.log('Replaying transaction...');
-//         await controller.invoke(ethSigAuth, 'authenticate', {
-//           r: r,
-//           s: s,
-//           v: v,
-//           salt: proposalSalt,
-//           target: spaceAddress,
-//           function_selector: PROPOSE_SELECTOR,
-//           calldata: proposeCalldata,
-//         });
-//         throw { message: 'replay attack worked on `propose`' };
-//       } catch (err: any) {
-//         expect(err.message).to.contain('Salt already used');
-//       }
+      // -- Attempts a replay attack on `propose` method --
+      // Expected to fail
+      try {
+        console.log('Replaying transaction...');
+        await controller.invoke(ethSigAuth, 'authenticate', {
+          r: r,
+          s: s,
+          v: v,
+          salt: proposalSalt,
+          target: spaceAddress,
+          function_selector: PROPOSE_SELECTOR,
+          calldata: proposeCalldata,
+        });
+        throw { message: 'replay attack worked on `propose`' };
+      } catch (err: any) {
+        expect(err.message).to.contain('Salt already used');
+      }
 
-//       // We can't directly compare the `info` object because we don't know for sure the value of `start_block` (and hence `end_block`),
-//       // so we compare it element by element.
-//       const _executionHash = proposal_info.proposal.execution_hash;
-//       expect(_executionHash).to.deep.equal(BigInt(executionHash));
+      // We can't directly compare the `info` object because we don't know for sure the value of `start_block` (and hence `end_block`),
+      // so we compare it element by element.
+      const _executionHash = proposal_info.proposal.execution_hash;
+      expect(_executionHash).to.deep.equal(BigInt(executionHash));
 
-//       const _for = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_for).toUint();
-//       expect(_for).to.deep.equal(BigInt(0));
-//       const against = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_against).toUint();
-//       expect(against).to.deep.equal(BigInt(0));
-//       const abstain = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_abstain).toUint();
-//       expect(abstain).to.deep.equal(BigInt(0));
-//     }
+      const _for = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_for).toUint();
+      expect(_for).to.deep.equal(BigInt(0));
+      const against = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_against).toUint();
+      expect(against).to.deep.equal(BigInt(0));
+      const abstain = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_abstain).toUint();
+      expect(abstain).to.deep.equal(BigInt(0));
+    }
 
-//     // -- Casts a vote FOR --
-//     {
-//       console.log('Casting a vote FOR...');
-//       const accounts = await ethers.getSigners();
-//       const spaceStr = utils.encoding.hexPadRight(space.address);
-//       const voteSalt = utils.splitUint256.SplitUint256.fromHex('0x02');
-//       const usedVotingStrategiesHashPadded2 = hexPadRight(usedVotingStrategiesHash2);
-//       const userVotingStrategyParamsFlatHashPadded2 = hexPadRight(
-//         userVotingStrategyParamsFlatHash2
-//       );
-//       const voterEthAddressPadded = hexPadRight(voterEthAddress);
+    // -- Casts a vote FOR --
+    {
+      console.log('Casting a vote FOR...');
+      const accounts = await ethers.getSigners();
+      const spaceStr = utils.encoding.hexPadRight(space.address);
+      const voteSalt = utils.splitUint256.SplitUint256.fromHex('0x02');
+      const usedVotingStrategiesHashPadded2 = hexPadRight(usedVotingStrategiesHash2);
+      const userVotingStrategyParamsFlatHashPadded2 = hexPadRight(
+        userVotingStrategyParamsFlatHash2
+      );
+      const voterEthAddressPadded = hexPadRight(voterEthAddress);
 
-//       const message: Vote = {
-//         space: spaceStr,
-//         voterAddress: voterEthAddressPadded,
-//         proposal: BigInt(proposalId).toString(16),
-//         choice: utils.choice.Choice.FOR,
-//         usedVotingStrategiesHash: usedVotingStrategiesHashPadded2,
-//         userVotingStrategyParamsFlatHash: userVotingStrategyParamsFlatHashPadded2,
-//         salt: voteSalt.toHex(),
-//       };
-//       const sig = await accounts[0]._signTypedData(domain, voteTypes, message);
+      const message: Vote = {
+        space: spaceStr,
+        voterAddress: voterEthAddressPadded,
+        proposal: BigInt(proposalId).toString(16),
+        choice: utils.choice.Choice.FOR,
+        usedVotingStrategiesHash: usedVotingStrategiesHashPadded2,
+        userVotingStrategyParamsFlatHash: userVotingStrategyParamsFlatHashPadded2,
+        salt: voteSalt.toHex(),
+      };
+      const sig = await accounts[0]._signTypedData(domain, voteTypes, message);
 
-//       const { r, s, v } = utils.encoding.getRSVFromSig(sig);
-//       const voteCalldata = utils.encoding.getVoteCalldata(
-//         voterEthAddress,
-//         proposalId,
-//         utils.choice.Choice.FOR,
-//         usedVotingStrategies1,
-//         userVotingParamsAll1
-//       );
-//       await controller.invoke(ethSigAuth, 'authenticate', {
-//         r: r,
-//         s: s,
-//         v: v,
-//         salt: voteSalt,
-//         target: spaceAddress,
-//         function_selector: VOTE_SELECTOR,
-//         calldata: voteCalldata,
-//       });
+      const { r, s, v } = utils.encoding.getRSVFromSig(sig);
+      const voteCalldata = utils.encoding.getVoteCalldata(
+        voterEthAddress,
+        proposalId,
+        utils.choice.Choice.FOR,
+        usedVotingStrategies1,
+        userVotingParamsAll1
+      );
+      await controller.invoke(ethSigAuth, 'authenticate', {
+        r: r,
+        s: s,
+        v: v,
+        salt: voteSalt,
+        target: spaceAddress,
+        function_selector: VOTE_SELECTOR,
+        calldata: voteCalldata,
+      });
 
-//       console.log('Getting proposal info...');
-//       const { proposal_info } = await space.call('get_proposal_info', {
-//         proposal_id: proposalId,
-//       });
+      console.log('Getting proposal info...');
+      const { proposal_info } = await space.call('get_proposal_info', {
+        proposal_id: proposalId,
+      });
 
-//       const _for = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_for).toUint();
-//       expect(_for).to.deep.equal(BigInt(1));
-//       const against = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_against).toUint();
-//       expect(against).to.deep.equal(BigInt(0));
-//       const abstain = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_abstain).toUint();
-//       expect(abstain).to.deep.equal(BigInt(0));
+      const _for = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_for).toUint();
+      expect(_for).to.deep.equal(BigInt(1));
+      const against = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_against).toUint();
+      expect(against).to.deep.equal(BigInt(0));
+      const abstain = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_abstain).toUint();
+      expect(abstain).to.deep.equal(BigInt(0));
 
-//       // -- Attempts a replay attack on `vote` method --
-//       try {
-//         console.log('Replaying vote...');
-//         await controller.invoke(ethSigAuth, 'authenticate', {
-//           r: r,
-//           s: s,
-//           v: v,
-//           salt: voteSalt,
-//           target: spaceAddress,
-//           function_selector: VOTE_SELECTOR,
-//           calldata: voteCalldata,
-//         });
-//         throw { message: 'replay attack worked on `vote`' };
-//       } catch (err: any) {
-//         expect(err.message).to.contain('Salt already used');
-//       }
-//     }
-//   }).timeout(6000000);
-// });
+      // -- Attempts a replay attack on `vote` method --
+      try {
+        console.log('Replaying vote...');
+        await controller.invoke(ethSigAuth, 'authenticate', {
+          r: r,
+          s: s,
+          v: v,
+          salt: voteSalt,
+          target: spaceAddress,
+          function_selector: VOTE_SELECTOR,
+          calldata: voteCalldata,
+        });
+        throw { message: 'replay attack worked on `vote`' };
+      } catch (err: any) {
+        expect(err.message).to.contain('Salt already used');
+      }
+    }
+  }).timeout(6000000);
+});

--- a/test/starknet/EthereumSigAuth.test.ts
+++ b/test/starknet/EthereumSigAuth.test.ts
@@ -72,6 +72,7 @@ describe('Ethereum Sig Auth testing', () => {
     usedVotingStrategies1 = [vanillaVotingStrategy.address];
     userVotingParamsAll1 = [[]];
     executionStrategy = vanillaExecutionStrategy.address;
+    spaceAddress = space.address;
 
     executionParams = ['0x01']; // Random params
     executionHash = computeHashOnElements(executionParams);
@@ -159,7 +160,6 @@ describe('Ethereum Sig Auth testing', () => {
       const proposalSalt: utils.splitUint256.SplitUint256 =
         utils.splitUint256.SplitUint256.fromHex('0x01');
 
-      const spaceStr = hexPadRight(space.address);
       const executionHashPadded = hexPadRight(executionHash);
       const usedVotingStrategiesHashPadded1 = hexPadRight(usedVotingStrategiesHash1);
       const userVotingStrategyParamsFlatHashPadded1 = hexPadRight(
@@ -169,7 +169,7 @@ describe('Ethereum Sig Auth testing', () => {
       const paddedExecutor = hexPadRight(executionStrategy);
 
       const message: Propose = {
-        space: spaceStr,
+        space: spaceAddress,
         proposerAddress: paddedProposerAddress,
         metadataUri: METADATA_URI,
         executor: paddedExecutor,
@@ -189,7 +189,7 @@ describe('Ethereum Sig Auth testing', () => {
         s: s,
         v: v,
         salt: proposalSalt,
-        target: spaceStr,
+        target: spaceAddress,
         function_selector: PROPOSE_SELECTOR,
         calldata: proposeCalldata,
       });


### PR DESCRIPTION
After investigation, I found that calling `.address` in starknet.js would actually left pad the address with some zeroes.
In the cairo code however, I was right-padding with zeroes (as specified in EIP-712....).

This PR removes the right-padding done on the `space` address in the cairo code.
The `proposer_address` / `voter_address` are not padded because they are 20 bytes long and effectively right padded when constructing the EIP-712 hash in js... :)

Closes #292 