### PR TITLE
Add auth to ethsig

### DIFF
--- a/contracts/starknet/Authenticators/EthSig.cairo
+++ b/contracts/starknet/Authenticators/EthSig.cairo
@@ -20,6 +20,7 @@ from starkware.cairo.common.bitwise import bitwise_and
 from starkware.cairo.common.cairo_secp.signature import verify_eth_signature_uint256
 from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_contract_address
 
 # TODO maybe use OZ safemath when possible?
 
@@ -31,21 +32,24 @@ const VOTE_SELECTOR = 0x132bdf85fc8aa10ac3c22f02317f8f53d4b4f52235ed1eabb3a4cbbe
 const ETHEREUM_PREFIX = 0x1901
 
 # This is the `Proposal` typeHash, obtained by doing this:
-# keccak256("Propose(bytes32 space,bytes32 proposerAddress,string metadataUri,bytes32 executor,bytes32 executionParamsHash,bytes32 usedVotingStrategiesHash,bytes32 userVotingStrategyParamsFlatHash,uint256 salt)")
-const PROPOSAL_HASH_HIGH = 0xa1a96273f272324c66f87ba1a951949d
-const PROPOSAL_HASH_LOW = 0xa34effccf1463302bc6e241f37fe5ef7
+# keccak256("Propose(bytes32 authenticator,bytes32 space,bytes32 proposerAddress,string metadataUri,bytes32 executor,bytes32 executionParamsHash,bytes32 usedVotingStrategiesHash,bytes32 userVotingStrategyParamsFlatHash,uint256 salt)")
+# 0xdd4b6d662f476088f7bfd59cd7f3487d83e72c2166a7985fb62fa23315c6db8c
+const PROPOSAL_HASH_HIGH = 0xdd4b6d662f476088f7bfd59cd7f3487d
+const PROPOSAL_HASH_LOW = 0x83e72c2166a7985fb62fa23315c6db8c
 
 # This is the `Vote` typeHash, obtained by doing this:
-# keccak256("Vote(bytes32 space,bytes32 voterAddress,uint256 proposal,uint256 choice,bytes32 usedVotingStrategiesHash,bytes32 userVotingStrategyParamsFlatHash,uint256 salt)")
-const VOTE_HASH_HIGH = 0x0f76587b41b5c7810a4c8591d4d84385
-const VOTE_HASH_LOW = 0x85dba41961e8886710ef5d5cbe72713d
+# keccak256("Vote(bytes32 authenticator,bytes32 space,bytes32 voterAddress,uint256 proposal,uint256 choice,bytes32 usedVotingStrategiesHash,bytes32 userVotingStrategyParamsFlatHash,uint256 salt)")
+# 0x943c2de24cfb6aaea8956c0444db4921ef29792e6cd3ada75d9adbd50bd9760a
+const VOTE_HASH_HIGH = 0x943c2de24cfb6aaea8956c0444db4921
+const VOTE_HASH_LOW = 0xef29792e6cd3ada75d9adbd50bd9760a
 
 # This is the domainSeparator, obtained by using those fields (see more about it in EIP712):
 # name: 'snapshot-x',
 # version: '1'
-# Which returns: 0x4ea062c13aa1ccc0dde3383926ef913772c5ab51b06b74e448d6b02ce79ba93c
-const DOMAIN_HASH_HIGH = 0x4ea062c13aa1ccc0dde3383926ef9137
-const DOMAIN_HASH_LOW = 0x72c5ab51b06b74e448d6b02ce79ba93c
+# chainId: '0x534e5f474f45524c49'
+# Which returns: 0x043091edf1497234296cbcfabb6af2ac73449a969c5e0d2c5429cf8e7d9534e9
+const DOMAIN_HASH_HIGH = 0x043091edf1497234296cbcfabb6af2ac
+const DOMAIN_HASH_LOW = 0x73449a969c5e0d2c5429cf8e7d9534e9
 
 # Maps a tuple of (user, salt) to a boolean stating whether this tuple was already used or not (to prevent replay attack).
 @storage_var
@@ -215,6 +219,9 @@ func authenticate_proposal{
     # Proposer address should be located in calldata[0]
     let proposer_address = calldata[0]
 
+    let (authenticator_address) = get_contract_address()
+    let (auth_address_u256) = FeltUtils.felt_to_uint256(authenticator_address)
+
     # Ensure proposer has not already used this salt in a previous action
     let (already_used) = salts.read(proposer_address, salt)
 
@@ -266,16 +273,17 @@ func authenticate_proposal{
     let (data : Uint256*) = alloc()
 
     assert data[0] = Uint256(PROPOSAL_HASH_LOW, PROPOSAL_HASH_HIGH)
-    assert data[1] = space
-    assert data[2] = padded_proposer_address
-    assert data[3] = metadata_uri_hash
-    assert data[4] = executor_u256
-    assert data[5] = execution_hash
-    assert data[6] = used_voting_strategies_hash
-    assert data[7] = user_voting_strategy_params_flat_hash
-    assert data[8] = salt
+    assert data[1] = auth_address_u256
+    assert data[2] = space
+    assert data[3] = padded_proposer_address
+    assert data[4] = metadata_uri_hash
+    assert data[5] = executor_u256
+    assert data[6] = execution_hash
+    assert data[7] = used_voting_strategies_hash
+    assert data[8] = user_voting_strategy_params_flat_hash
+    assert data[9] = salt
 
-    let (hash_struct) = get_keccak_hash{keccak_ptr=keccak_ptr}(9, data)
+    let (hash_struct) = get_keccak_hash{keccak_ptr=keccak_ptr}(10, data)
 
     # Prepare the encoded data
     let (prepared_encoded : Uint256*) = alloc()
@@ -325,6 +333,9 @@ func authenticate_vote{
 
     let voter_address = calldata[0]
 
+    let (authenticator_address) = get_contract_address()
+    let (auth_address_u256) = FeltUtils.felt_to_uint256(authenticator_address)
+
     # Ensure voter has not already used this salt in a previous action
     let (already_used) = salts.read(voter_address, salt)
 
@@ -357,18 +368,19 @@ func authenticate_vote{
     # Now construct the data hash (hashStruct)
     let (data : Uint256*) = alloc()
     assert data[0] = Uint256(VOTE_HASH_LOW, VOTE_HASH_HIGH)
-    assert data[1] = space
-    assert data[2] = padded_voter_address
-    assert data[3] = proposal_id
-    assert data[4] = choice
-    assert data[5] = used_voting_strategies_hash
-    assert data[6] = user_voting_strategy_params_flat_hash
-    assert data[7] = salt
+    assert data[1] = auth_address_u256
+    assert data[2] = space
+    assert data[3] = padded_voter_address
+    assert data[4] = proposal_id
+    assert data[5] = choice
+    assert data[6] = used_voting_strategies_hash
+    assert data[7] = user_voting_strategy_params_flat_hash
+    assert data[8] = salt
 
     let (local keccak_ptr : felt*) = alloc()
     let keccak_ptr_start = keccak_ptr
 
-    let (hash_struct) = get_keccak_hash{keccak_ptr=keccak_ptr}(8, data)
+    let (hash_struct) = get_keccak_hash{keccak_ptr=keccak_ptr}(9, data)
 
     # Prepare the encoded data
     let (prepared_encoded : Uint256*) = alloc()

--- a/test/shared/types.ts
+++ b/test/shared/types.ts
@@ -1,10 +1,12 @@
 export const domain = {
   name: 'snapshot-x',
   version: '1',
+  chainId: '0x534e5f474f45524c49', // SN_GOERLI
 };
 
 export const proposeTypes = {
   Propose: [
+    { name: 'authenticator', type: 'bytes32' },
     { name: 'space', type: 'bytes32' },
     { name: 'proposerAddress', type: 'bytes32' },
     { name: 'metadataUri', type: 'string' },
@@ -18,6 +20,7 @@ export const proposeTypes = {
 
 export const voteTypes = {
   Vote: [
+    { name: 'authenticator', type: 'bytes32' },
     { name: 'space', type: 'bytes32' },
     { name: 'voterAddress', type: 'bytes32' },
     { name: 'proposal', type: 'uint256' },
@@ -29,6 +32,7 @@ export const voteTypes = {
 };
 
 export interface Propose {
+  authenticator: string;
   space: string;
   proposerAddress: string;
   metadataUri: string;
@@ -40,6 +44,7 @@ export interface Propose {
 }
 
 export interface Vote {
+  authenticator: string;
   space: string;
   voterAddress: string;
   proposal: string;

--- a/test/starknet/EthereumSigAuth.test.ts
+++ b/test/starknet/EthereumSigAuth.test.ts
@@ -6,7 +6,7 @@ import { computeHashOnElements } from 'starknet/dist/utils/hash';
 import { utils } from '@snapshot-labs/sx';
 import { ethereumSigAuthSetup } from '../shared/setup';
 import { PROPOSE_SELECTOR, VOTE_SELECTOR } from '../shared/constants';
-import { _TypedDataEncoder } from 'ethers/lib/utils';
+import { keccak256, _TypedDataEncoder } from 'ethers/lib/utils';
 
 export const VITALIK_ADDRESS = BigInt('0xd8da6bf26964af9d7eed9e03e53415d37aa96045');
 export const AUTHENTICATE_METHOD = 'authenticate';
@@ -120,6 +120,7 @@ describe('Ethereum Sig Auth testing', () => {
       const paddedProposerAddress = hexPadRight(proposerEthAddress);
       const paddedExecutor = hexPadRight(vanillaExecutionStrategy.address);
       const message: Propose = {
+        authenticator: ethSigAuth.address,
         space: spaceStr,
         proposerAddress: paddedProposerAddress,
         metadataUri: METADATA_URI,
@@ -169,6 +170,7 @@ describe('Ethereum Sig Auth testing', () => {
       const paddedExecutor = hexPadRight(executionStrategy);
 
       const message: Propose = {
+        authenticator: ethSigAuth.address,
         space: spaceAddress,
         proposerAddress: paddedProposerAddress,
         metadataUri: METADATA_URI,
@@ -243,6 +245,7 @@ describe('Ethereum Sig Auth testing', () => {
       const voterEthAddressPadded = hexPadRight(voterEthAddress);
 
       const message: Vote = {
+        authenticator: ethSigAuth.address,
         space: spaceStr,
         voterAddress: voterEthAddressPadded,
         proposal: BigInt(proposalId).toString(16),


### PR DESCRIPTION
- Adds the `authenticator` parameter to the EthSig.cairo authenticator
- Also adds `chainId` to the domain