### PR TITLE
Add amarna static analyser to CI

### DIFF
--- a/.github/workflows/amarna.yml
+++ b/.github/workflows/amarna.yml
@@ -1,0 +1,25 @@
+name: Amarna Analysis
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Amarna
+        uses: crytic/amarna-action@v0.1.1
+        id: amarna
+        continue-on-error: true
+        with:
+          amarna-args: --exclude-rules=arithmetic-add
+          sarif: results.sarif
+          target: 'contracts/starknet/'
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.amarna.outputs.sarif }}
+          checkout_path: '/github/workspace'


### PR DESCRIPTION
Closes #97 

`amarna` just released support for cairo 0.1.0 https://github.com/crytic/amarna/releases/tag/v0.1.5

Here we run amarna excluding `arithmetic-add` and upload the results to the gh workspace.