### PR TITLE
Throw in all try/catch assertions to catch false-positive tests

### DIFF
--- a/contracts/starknet/lib/voting.cairo
+++ b/contracts/starknet/lib/voting.cairo
@@ -799,6 +799,9 @@ namespace Voting {
         proposal_id: felt
     ) -> (proposal_info: ProposalInfo) {
         let (proposal) = Voting_proposal_registry_store.read(proposal_id);
+        with_attr error_message("Voting: Proposal does not exist") {
+            assert_not_zero(proposal.timestamps);
+        }
 
         let (power_against) = Voting_vote_power_store.read(proposal_id, Choice.AGAINST);
         let (power_for) = Voting_vote_power_store.read(proposal_id, Choice.FOR);

--- a/test/crosschain/EthTxAuth.test.ts
+++ b/test/crosschain/EthTxAuth.test.ts
@@ -5,7 +5,7 @@ import { starknet, network, ethers } from 'hardhat';
 import { StarknetContract, Account, HttpNetworkConfig } from 'hardhat/types';
 import { utils } from '@snapshot-labs/sx';
 import { ethTxAuthSetup } from '../shared/setup';
-import { PROPOSE_SELECTOR } from '../shared/constants';
+import { PROPOSE_SELECTOR, VOTE_SELECTOR } from '../shared/constants';
 
 describe('L1 interaction with Snapshot X', function () {
   this.timeout(5000000);
@@ -116,7 +116,7 @@ describe('L1 interaction with Snapshot X', function () {
       .connect(signer)
       .commit(
         ethTxAuth.address,
-        utils.encoding.getCommit(spaceAddress, PROPOSE_SELECTOR, proposeCalldata)
+        utils.encoding.getCommit(spaceAddress, VOTE_SELECTOR, proposeCalldata)
       ); // Wrong selector
     await starknet.devnet.flush();
     try {

--- a/test/crosschain/EthTxAuth.test.ts
+++ b/test/crosschain/EthTxAuth.test.ts
@@ -104,6 +104,7 @@ describe('L1 interaction with Snapshot X', function () {
         function_selector: PROPOSE_SELECTOR,
         calldata: proposeCalldata,
       });
+      throw { message: 'committed multiple times' };
     } catch (err: any) {
       expect(err.message).to.contain('EthTx: Hash not yet committed or already executed');
     }
@@ -124,6 +125,7 @@ describe('L1 interaction with Snapshot X', function () {
         function_selector: PROPOSE_SELECTOR,
         calldata: proposeCalldata,
       });
+      throw { message: 'succeeded without hash commit' };
     } catch (err: any) {
       expect(err.message).to.contain('EthTx: Hash not yet committed or already executed');
     }
@@ -145,6 +147,7 @@ describe('L1 interaction with Snapshot X', function () {
         function_selector: PROPOSE_SELECTOR,
         calldata: proposeCalldata,
       });
+      throw { message: 'succeeded with invalid commit sender' };
     } catch (err: any) {
       expect(err.message).to.contain('EthTx: Commit made by invalid L1 address');
     }

--- a/test/crosschain/EthTxSessionKeyAuth.test.ts
+++ b/test/crosschain/EthTxSessionKeyAuth.test.ts
@@ -195,6 +195,7 @@ describe('Ethereum Transaction Session Keys', function () {
         session_public_key: sessionPublicKey,
         session_duration: fakeSessionDuration,
       });
+      throw { message: 'succeeded without hash commit' };
     } catch (err: any) {
       expect(err.message).to.contain('EthTx: Hash not yet committed or already executed');
     }
@@ -215,6 +216,7 @@ describe('Ethereum Transaction Session Keys', function () {
         session_public_key: sessionPublicKey,
         session_duration: sessionDuration,
       });
+      throw { message: 'succeeded with invalid commit sender' };
     } catch (err: any) {
       expect(err.message).to.contain('EthTx: Commit made by invalid L1 address');
     }

--- a/test/starknet/ArrayUtils.test.ts
+++ b/test/starknet/ArrayUtils.test.ts
@@ -84,6 +84,7 @@ describe('Array Utilities', () => {
       await testArrayUtils.call('test_assert_no_duplicates', {
         array: [1, 0, 3, 4, 2, 0],
       });
+      throw { message: 'duplicate was allowed' };
     } catch (error: any) {
       expect(error.message).to.contain('Duplicate entry found');
     }

--- a/test/starknet/ExecutionStrategyWhitelist.test.ts
+++ b/test/starknet/ExecutionStrategyWhitelist.test.ts
@@ -106,6 +106,7 @@ describe('Execution Strategy Whitelist testing', () => {
         function_selector: PROPOSE_SELECTOR,
         calldata: proposeCalldata2,
       });
+      throw { message: 'proposal created with non whitelisted execution strategy' };
     } catch (err: any) {
       expect(err.message).to.contain('Voting: Invalid execution strategy');
     }
@@ -141,6 +142,7 @@ describe('Execution Strategy Whitelist testing', () => {
         function_selector: PROPOSE_SELECTOR,
         calldata: proposeCalldata1,
       });
+      throw { message: 'proposal not removed from whitelist' };
     } catch (err: any) {
       expect(err.message).to.contain('Voting: Invalid execution strategy');
     }

--- a/test/starknet/MathUtils.test.ts
+++ b/test/starknet/MathUtils.test.ts
@@ -59,7 +59,7 @@ describe('Felt Utils:', () => {
 
   it('Packing should fail if a number greater than 32 bits is used', async () => {
     const num1 = utils.bytes.bytesToHex(ethers.utils.randomBytes(4));
-    const num2 = '0xfffff'; // 36 bits
+    const num2 = '0xfffffffff'; // 36 bits
     const num3 = utils.bytes.bytesToHex(ethers.utils.randomBytes(4));
     const num4 = utils.bytes.bytesToHex(ethers.utils.randomBytes(4));
     try {
@@ -69,6 +69,7 @@ describe('Felt Utils:', () => {
         num3: num3,
         num4: num4,
       });
+      throw { message: 'packing succeeded with a number greater than 32 bits' };
     } catch (error: any) {
       expect(error.message).to.contain('MathUtils: number too big to be packed');
     }

--- a/test/starknet/MerkleProof.test.ts
+++ b/test/starknet/MerkleProof.test.ts
@@ -145,6 +145,7 @@ describe('Merkle:', () => {
           leaf: [leafData[1], leafData[2]],
           proof: corruptedProof,
         });
+        throw { message: 'invalid leaf asserted to be valid' };
       } catch (error: any) {
         expect(error.message).to.contain('Merkle: Invalid proof');
       }
@@ -157,6 +158,7 @@ describe('Merkle:', () => {
           leaf: ['0x0', '0x0'],
           proof: '0x0',
         });
+        throw { message: 'invalid leaf asserted to be valid' };
       } catch (error: any) {
         expect(error.message).to.contain('Merkle: Invalid proof');
       }

--- a/test/starknet/MerkleWhitelist.test.ts
+++ b/test/starknet/MerkleWhitelist.test.ts
@@ -118,6 +118,7 @@ describe('Merkle Whitelist testing', () => {
           ...tree.getProof(leaves, Number(leaf1[3])),
         ],
       });
+      throw { message: 'voting power returned for invalid proof' };
     } catch (err: any) {
       expect(err.message).to.contain('MerkleWhitelist: Invalid proof supplied');
     }

--- a/test/starknet/Space.test.ts
+++ b/test/starknet/Space.test.ts
@@ -131,6 +131,7 @@ describe('Space Testing', () => {
           executionParams
         ),
       });
+      throw { message: 'succeeded with invalid voting strategy' };
     } catch (error: any) {
       expect(error.message).to.contain('Voting: Invalid voting strategy');
     }
@@ -159,6 +160,7 @@ describe('Space Testing', () => {
           function_selector: PROPOSE_SELECTOR,
           calldata: duplicateCalldata,
         });
+        throw { message: 'same voting strategy was used multiple times' };
       } catch (error: any) {
         expect(error.message).to.contain('ArrayUtils: Duplicate entry found');
       }
@@ -251,6 +253,7 @@ describe('Space Testing', () => {
         proposal_id: 0x3,
         execution_params: executionParams,
       });
+      throw { message: 'proposal finalized with insufficient quorum' };
     } catch (error: any) {
       expect(error.message).to.contain('Voting: Quorum has not been reached');
     }
@@ -268,18 +271,21 @@ describe('Space Testing', () => {
         proposal_id: 0x3,
         execution_params: executionParams,
       });
+      throw { message: 'proposal passed with insufficient quorum' };
     } catch (error: any) {
       expect(error.message).to.contain('TestExecutionStrategy: Proposal was rejected');
     }
   });
 
-  it('Reverts when querying an invalid proposal id', async () => {
-    try {
-      await space.call('getProposalInfo', {
-        proposal_id: 42,
-      });
-    } catch (error: any) {
-      expect(error.message).to.contain('Voting: Proposal does not exist');
-    }
+  it('Returns empty proposal info when querying an invalid proposal id', async () => {
+    const { proposal_info } = await space.call('getProposalInfo', {
+      proposal_id: 42,
+    });
+    const _for = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_for).toUint();
+    expect(_for).to.deep.equal(BigInt(0));
+    const against = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_against).toUint();
+    expect(against).to.deep.equal(BigInt(0));
+    const abstain = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_abstain).toUint();
+    expect(abstain).to.deep.equal(BigInt(0));
   }).timeout(6000000);
 });

--- a/test/starknet/Space.test.ts
+++ b/test/starknet/Space.test.ts
@@ -277,15 +277,14 @@ describe('Space Testing', () => {
     }
   });
 
-  it('Returns empty proposal info when querying an invalid proposal id', async () => {
-    const { proposal_info } = await space.call('getProposalInfo', {
-      proposal_id: 42,
-    });
-    const _for = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_for).toUint();
-    expect(_for).to.deep.equal(BigInt(0));
-    const against = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_against).toUint();
-    expect(against).to.deep.equal(BigInt(0));
-    const abstain = utils.splitUint256.SplitUint256.fromObj(proposal_info.power_abstain).toUint();
-    expect(abstain).to.deep.equal(BigInt(0));
+  it('Reverts when querying an invalid proposal id', async () => {
+    try {
+      await space.call('getProposalInfo', {
+        proposal_id: 42,
+      });
+      throw { message: 'invalid proposal id query did not revert' };
+    } catch (error: any) {
+      expect(error.message).to.contain('Voting: Proposal does not exist');
+    }
   }).timeout(6000000);
 });


### PR DESCRIPTION
This PR adds a `throw` statement at the end of all `try` blocks found in the tests to ensure that tests cannot pass because the expected error was not thrown.

This caught three false-positives:

* `Packing should fail if a number greater than 32 bits is used` - The test number used did not actually have 36 bits.
* `Reverts when querying an invalid proposal id` - This function is not expected to revert when a proposal ID does not exist.
* `Authentication should fail if the correct hash of the payload is not committed on l1 before execution is called` - The test was using the correct selector.