### PR TITLE
Refactor settings setters; use snapshots for events

### DIFF
--- a/ethereum/remappings.txt
+++ b/ethereum/remappings.txt
@@ -1,1 +1,2 @@
 @gnosis.pm/safe-contracts=lib/safe-contracts
+@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts

--- a/ethereum/src/execution-strategies/StarknetSpaceManager.sol
+++ b/ethereum/src/execution-strategies/StarknetSpaceManager.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.19;
 
-import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 /// @title Space Manager - A contract that manages SX spaces on Starknet that are able to execute transactions via this contract
 /// @author Snapshot Labs

--- a/ethereum/src/execution-strategies/StarknetSpaceManager.sol
+++ b/ethereum/src/execution-strategies/StarknetSpaceManager.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.19;
 
-import "openzeppelin/access/OwnableUpgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 /// @title Space Manager - A contract that manages SX spaces on Starknet that are able to execute transactions via this contract
 /// @author Snapshot Labs

--- a/starknet/src/space/space.cairo
+++ b/starknet/src/space/space.cairo
@@ -1,6 +1,6 @@
 use core::traits::Destruct;
 use starknet::ContractAddress;
-use sx::utils::types::{Strategy, Proposal, IndexedStrategy, Choice};
+use sx::utils::types::{Strategy, Proposal, IndexedStrategy, Choice, UpdateSettingsCalldata};
 
 #[starknet::interface]
 trait ISpace<TContractState> {
@@ -24,16 +24,7 @@ trait ISpace<TContractState> {
     // fn get_proposal_status(proposal_id: u256) -> u8;
 
     // Owner Actions 
-    fn set_max_voting_duration(ref self: TContractState, max_voting_duration: u64);
-    fn set_min_voting_duration(ref self: TContractState, min_voting_duration: u64);
-    fn set_voting_delay(ref self: TContractState, voting_delay: u64);
-    fn set_proposal_validation_strategy(
-        ref self: TContractState, proposal_validation_strategy: Strategy
-    );
-    fn add_voting_strategies(ref self: TContractState, voting_strategies: Array<Strategy>);
-    fn remove_voting_strategies(ref self: TContractState, voting_strategy_indices: Array<u8>);
-    fn add_authenticators(ref self: TContractState, authenticators: Array<ContractAddress>);
-    fn remove_authenticators(ref self: TContractState, authenticators: Array<ContractAddress>);
+    fn update_settings(ref self: TContractState, input: UpdateSettingsCalldata);
     fn transfer_ownership(ref self: TContractState, new_owner: ContractAddress);
     fn renounce_ownership(ref self: TContractState);
     // Actions 
@@ -79,7 +70,7 @@ mod Space {
     use sx::utils::{
         types::{
             Choice, FinalizationStatus, Strategy, IndexedStrategy, Proposal, IndexedStrategyTrait,
-            IndexedStrategyImpl
+            IndexedStrategyImpl, UpdateSettingsCalldata, NoUpdateU64, NoUpdateStrategy, NoUpdateArray
         },
         bits::BitSetter
     };
@@ -132,7 +123,8 @@ mod Space {
     #[event]
     fn ProposalCancelled(_proposal_id: u256) {}
 
-    fn VotingStrategiesAdded(_new_voting_strategies: Array<Strategy>) {}
+    #[event]
+    fn VotingStrategiesAdded(_new_voting_strategies: Array<Strategy>, _new_voting_strategy_metadata_uris: Array<Array<felt252>>) {}
 
     #[event]
     fn VotingStrategiesRemoved(_voting_strategy_indices: Array<u8>) {}
@@ -144,14 +136,20 @@ mod Space {
     fn AuthenticatorsRemoved(_authenticators: Array<ContractAddress>) {}
 
     #[event]
+    fn MetadataURIUpdated(_new_metadata_uri: Array<felt252>) {}
+
+    #[event]
+    fn DaoURIUpdated(_new_dao_uri: Array<felt252>) {}
+
+    #[event]
     fn MaxVotingDurationUpdated(_new_max_voting_duration: u64) {}
 
     #[event]
     fn MinVotingDurationUpdated(_new_min_voting_duration: u64) {}
 
     #[event]
-    fn ProposalValidationStrategyUpdated(_new_proposal_validation_strategy: Strategy) {}
-
+    fn ProposalValidationStrategyUpdated(_new_proposal_validation_strategy: Strategy, _new_proposal_validation_strategy_metadata_URI: Array<felt252>) {}
+    
     #[event]
     fn VotingDelayUpdated(_new_voting_delay: u64) {}
 
@@ -356,72 +354,65 @@ mod Space {
             self._proposals.read(proposal_id)
         }
 
-        fn set_max_voting_duration(ref self: ContractState, max_voting_duration: u64) {
+        fn update_settings(ref self: ContractState, input: UpdateSettingsCalldata) {
             //TODO: temporary component syntax
             let state: Ownable::ContractState = Ownable::unsafe_new_contract_state();
             Ownable::assert_only_owner(@state);
-            _set_max_voting_duration(ref self, max_voting_duration);
-            MaxVotingDurationUpdated(max_voting_duration);
-        }
 
-        fn set_min_voting_duration(ref self: ContractState, min_voting_duration: u64) {
-            //TODO: temporary component syntax
-            let state: Ownable::ContractState = Ownable::unsafe_new_contract_state();
-            Ownable::assert_only_owner(@state);
-            _set_min_voting_duration(ref self, min_voting_duration);
-            MinVotingDurationUpdated(min_voting_duration);
-        }
+            // if not NO_UPDATE
+            if NoUpdateU64::should_update(@input.max_voting_duration) {
+                _set_max_voting_duration(ref self, input.max_voting_duration);
+                MaxVotingDurationUpdated(input.max_voting_duration);
+            }
 
-        fn set_voting_delay(ref self: ContractState, voting_delay: u64) {
-            //TODO: temporary component syntax
-            let state: Ownable::ContractState = Ownable::unsafe_new_contract_state();
-            Ownable::assert_only_owner(@state);
-            _set_voting_delay(ref self, voting_delay);
-            VotingDelayUpdated(voting_delay);
-        }
+            if NoUpdateU64::should_update(@input.min_voting_duration) {
+                _set_min_voting_duration(ref self, input.min_voting_duration);
+                MinVotingDurationUpdated(input.min_voting_duration);
+            }
 
-        fn set_proposal_validation_strategy(
-            ref self: ContractState, proposal_validation_strategy: Strategy
-        ) {
-            //TODO: temporary component syntax
-            let state: Ownable::ContractState = Ownable::unsafe_new_contract_state();
-            Ownable::assert_only_owner(@state);
-            // TODO: might be possible to remove need to clone by defining the event or setter on a snapshot.
-            // Similarly for all non value types.
-            _set_proposal_validation_strategy(ref self, proposal_validation_strategy.clone());
-            ProposalValidationStrategyUpdated(proposal_validation_strategy);
-        }
+            if NoUpdateU64::should_update(@input.voting_delay) {
+                _set_voting_delay(ref self, input.voting_delay);
+                VotingDelayUpdated(input.voting_delay);
+            }  
 
-        fn add_voting_strategies(ref self: ContractState, voting_strategies: Array<Strategy>) {
-            //TODO: temporary component syntax
-            let state: Ownable::ContractState = Ownable::unsafe_new_contract_state();
-            Ownable::assert_only_owner(@state);
-            _add_voting_strategies(ref self, voting_strategies.clone());
-            VotingStrategiesAdded(voting_strategies);
-        }
+            if NoUpdateArray::should_update((@input).metadata_URI) {
+                MetadataURIUpdated(input.metadata_URI.clone());
+            }
 
-        fn remove_voting_strategies(ref self: ContractState, voting_strategy_indices: Array<u8>) {
-            //TODO: temporary component syntax
-            let state: Ownable::ContractState = Ownable::unsafe_new_contract_state();
-            Ownable::assert_only_owner(@state);
-            _remove_voting_strategies(ref self, voting_strategy_indices.clone());
-            VotingStrategiesRemoved(voting_strategy_indices);
-        }
+            if NoUpdateArray::should_update((@input).dao_URI) {
+                DaoURIUpdated(input.dao_URI.clone());
+            }
 
-        fn add_authenticators(ref self: ContractState, authenticators: Array<ContractAddress>) {
-            //TODO: temporary component syntax
-            let state: Ownable::ContractState = Ownable::unsafe_new_contract_state();
-            Ownable::assert_only_owner(@state);
-            _add_authenticators(ref self, authenticators.clone());
-            AuthenticatorsAdded(authenticators);
-        }
+            // if not NO_UPDATE
+            if NoUpdateStrategy::should_update((@input).proposal_validation_strategy) {
+                // TODO: might be possible to remove need to clone by defining the event or setter on a snapshot.
+                // Similarly for all non value types.
+                _set_proposal_validation_strategy(ref self, input.proposal_validation_strategy.clone());
+                ProposalValidationStrategyUpdated(input.proposal_validation_strategy.clone(), input.proposal_validation_strategy_metadata_URI.clone());
+            }
 
-        fn remove_authenticators(ref self: ContractState, authenticators: Array<ContractAddress>) {
-            //TODO: temporary component syntax
-            let state: Ownable::ContractState = Ownable::unsafe_new_contract_state();
-            Ownable::assert_only_owner(@state);
-            _remove_authenticators(ref self, authenticators.clone());
-            AuthenticatorsRemoved(authenticators);
+            if NoUpdateArray::should_update((@input).authenticators_to_add) {
+                _add_authenticators(ref self, input.authenticators_to_add.clone());
+                AuthenticatorsAdded(input.authenticators_to_add.clone());
+            }
+
+            // if not NO_UPDATE
+            if NoUpdateArray::should_update((@input).authenticators_to_remove) {
+                _remove_authenticators(ref self, input.authenticators_to_remove.clone());
+                AuthenticatorsRemoved(input.authenticators_to_remove.clone());
+            }
+
+            // if not NO_UPDATE
+            if NoUpdateArray::should_update((@input).voting_strategies_to_add) {
+                _add_voting_strategies(ref self, input.voting_strategies_to_add.clone());
+                VotingStrategiesAdded(input.voting_strategies_to_add.clone(), input.voting_strategies_metadata_URIs_to_add.clone());
+            }
+
+            // if not NO_UPDATE
+            if NoUpdateArray::should_update((@input).voting_strategies_to_remove) {
+                _remove_voting_strategies(ref self, input.voting_strategies_to_remove.clone());
+                        VotingStrategiesRemoved(input.voting_strategies_to_remove.clone());
+            }
         }
 
         fn transfer_ownership(ref self: ContractState, new_owner: ContractAddress) {

--- a/starknet/src/space/space.cairo
+++ b/starknet/src/space/space.cairo
@@ -70,7 +70,8 @@ mod Space {
     use sx::utils::{
         types::{
             Choice, FinalizationStatus, Strategy, IndexedStrategy, Proposal, IndexedStrategyTrait,
-            IndexedStrategyImpl, UpdateSettingsCalldata, NoUpdateU64, NoUpdateStrategy, NoUpdateArray
+            IndexedStrategyImpl, UpdateSettingsCalldata, NoUpdateU64, NoUpdateStrategy,
+            NoUpdateArray
         },
         bits::BitSetter
     };
@@ -106,7 +107,10 @@ mod Space {
 
     #[event]
     fn ProposalCreated(
-        _proposal_id: u256, _author: ContractAddress, _proposal: @Proposal, _payload: @Array<felt252>
+        _proposal_id: u256,
+        _author: ContractAddress,
+        _proposal: @Proposal,
+        _payload: @Array<felt252>
     ) {}
 
     #[event]
@@ -124,7 +128,10 @@ mod Space {
     fn ProposalCancelled(_proposal_id: u256) {}
 
     #[event]
-    fn VotingStrategiesAdded(_new_voting_strategies: @Array<Strategy>, _new_voting_strategy_metadata_uris: @Array<Array<felt252>>) {}
+    fn VotingStrategiesAdded(
+        _new_voting_strategies: @Array<Strategy>,
+        _new_voting_strategy_metadata_uris: @Array<Array<felt252>>
+    ) {}
 
     #[event]
     fn VotingStrategiesRemoved(_voting_strategy_indices: @Array<u8>) {}
@@ -148,8 +155,11 @@ mod Space {
     fn MinVotingDurationUpdated(_new_min_voting_duration: u64) {}
 
     #[event]
-    fn ProposalValidationStrategyUpdated(_new_proposal_validation_strategy: @Strategy, _new_proposal_validation_strategy_metadata_URI: @Array<felt252>) {}
-    
+    fn ProposalValidationStrategyUpdated(
+        _new_proposal_validation_strategy: @Strategy,
+        _new_proposal_validation_strategy_metadata_URI: @Array<felt252>
+    ) {}
+
     #[event]
     fn VotingDelayUpdated(_new_voting_delay: u64) {}
 
@@ -374,7 +384,7 @@ mod Space {
             if NoUpdateU64::should_update(@input.voting_delay) {
                 _set_voting_delay(ref self, input.voting_delay);
                 VotingDelayUpdated(input.voting_delay);
-            }  
+            }
 
             if NoUpdateArray::should_update((@input).metadata_URI) {
                 MetadataURIUpdated(@input.metadata_URI);
@@ -388,8 +398,13 @@ mod Space {
             if NoUpdateStrategy::should_update((@input).proposal_validation_strategy) {
                 // TODO: might be possible to remove need to clone by defining the event or setter on a snapshot.
                 // Similarly for all non value types.
-                _set_proposal_validation_strategy(ref self, input.proposal_validation_strategy.clone());
-                ProposalValidationStrategyUpdated(@input.proposal_validation_strategy, @input.proposal_validation_strategy_metadata_URI);
+                _set_proposal_validation_strategy(
+                    ref self, input.proposal_validation_strategy.clone()
+                );
+                ProposalValidationStrategyUpdated(
+                    @input.proposal_validation_strategy,
+                    @input.proposal_validation_strategy_metadata_URI
+                );
             }
 
             if NoUpdateArray::should_update((@input).authenticators_to_add) {
@@ -406,13 +421,15 @@ mod Space {
             // if not NO_UPDATE
             if NoUpdateArray::should_update((@input).voting_strategies_to_add) {
                 _add_voting_strategies(ref self, input.voting_strategies_to_add.clone());
-                VotingStrategiesAdded(@input.voting_strategies_to_add, @input.voting_strategies_metadata_URIs_to_add);
+                VotingStrategiesAdded(
+                    @input.voting_strategies_to_add, @input.voting_strategies_metadata_URIs_to_add
+                );
             }
 
             // if not NO_UPDATE
             if NoUpdateArray::should_update((@input).voting_strategies_to_remove) {
                 _remove_voting_strategies(ref self, input.voting_strategies_to_remove.clone());
-                        VotingStrategiesRemoved(@input.voting_strategies_to_remove);
+                VotingStrategiesRemoved(@input.voting_strategies_to_remove);
             }
         }
 

--- a/starknet/src/space/space.cairo
+++ b/starknet/src/space/space.cairo
@@ -99,14 +99,14 @@ mod Space {
         _voting_delay: u64,
         _min_voting_duration: u64,
         _max_voting_duration: u64,
-        _proposal_validation_strategy: Strategy,
-        _voting_strategies: Array<Strategy>,
-        _authenticators: Array<ContractAddress>
+        _proposal_validation_strategy: @Strategy,
+        _voting_strategies: @Array<Strategy>,
+        _authenticators: @Array<ContractAddress>
     ) {}
 
     #[event]
     fn ProposalCreated(
-        _proposal_id: u256, _author: ContractAddress, _proposal: Proposal, _payload: Array<felt252>
+        _proposal_id: u256, _author: ContractAddress, _proposal: @Proposal, _payload: @Array<felt252>
     ) {}
 
     #[event]
@@ -196,13 +196,14 @@ mod Space {
                 finalization_status: FinalizationStatus::Pending(()),
                 active_voting_strategies: self._active_voting_strategies.read()
             };
+            let snap_proposal = @proposal;
 
             // TODO: Lots of copying, maybe figure out how to pass snapshots to events/storage writers. 
-            self._proposals.write(proposal_id, proposal.clone());
+            self._proposals.write(proposal_id, proposal);
 
             self._next_proposal_id.write(proposal_id + u256 { low: 1_u128, high: 0_u128 });
 
-            ProposalCreated(proposal_id, author, proposal, execution_strategy.params);
+            ProposalCreated(proposal_id, author, snap_proposal, @execution_strategy.params);
         }
 
         fn vote(
@@ -458,9 +459,9 @@ mod Space {
             _voting_delay,
             _min_voting_duration,
             _max_voting_duration,
-            _proposal_validation_strategy,
-            _voting_strategies,
-            _authenticators
+            @_proposal_validation_strategy,
+            @_voting_strategies,
+            @_authenticators
         );
     }
 

--- a/starknet/src/space/space.cairo
+++ b/starknet/src/space/space.cairo
@@ -118,28 +118,28 @@ mod Space {
     fn ProposalExecuted(_proposal_id: u256) {}
 
     #[event]
-    fn ProposalUpdated(_proposal_id: u256, _execution_stategy: Strategy) {}
+    fn ProposalUpdated(_proposal_id: u256, _execution_stategy: @Strategy) {}
 
     #[event]
     fn ProposalCancelled(_proposal_id: u256) {}
 
     #[event]
-    fn VotingStrategiesAdded(_new_voting_strategies: Array<Strategy>, _new_voting_strategy_metadata_uris: Array<Array<felt252>>) {}
+    fn VotingStrategiesAdded(_new_voting_strategies: @Array<Strategy>, _new_voting_strategy_metadata_uris: @Array<Array<felt252>>) {}
 
     #[event]
-    fn VotingStrategiesRemoved(_voting_strategy_indices: Array<u8>) {}
+    fn VotingStrategiesRemoved(_voting_strategy_indices: @Array<u8>) {}
 
     #[event]
-    fn AuthenticatorsAdded(_new_authenticators: Array<ContractAddress>) {}
+    fn AuthenticatorsAdded(_new_authenticators: @Array<ContractAddress>) {}
 
     #[event]
-    fn AuthenticatorsRemoved(_authenticators: Array<ContractAddress>) {}
+    fn AuthenticatorsRemoved(_authenticators: @Array<ContractAddress>) {}
 
     #[event]
-    fn MetadataURIUpdated(_new_metadata_uri: Array<felt252>) {}
+    fn MetadataURIUpdated(_new_metadata_uri: @Array<felt252>) {}
 
     #[event]
-    fn DaoURIUpdated(_new_dao_uri: Array<felt252>) {}
+    fn DaoURIUpdated(_new_dao_uri: @Array<felt252>) {}
 
     #[event]
     fn MaxVotingDurationUpdated(_new_max_voting_duration: u64) {}
@@ -148,7 +148,7 @@ mod Space {
     fn MinVotingDurationUpdated(_new_min_voting_duration: u64) {}
 
     #[event]
-    fn ProposalValidationStrategyUpdated(_new_proposal_validation_strategy: Strategy, _new_proposal_validation_strategy_metadata_URI: Array<felt252>) {}
+    fn ProposalValidationStrategyUpdated(_new_proposal_validation_strategy: @Strategy, _new_proposal_validation_strategy_metadata_URI: @Array<felt252>) {}
     
     #[event]
     fn VotingDelayUpdated(_new_voting_delay: u64) {}
@@ -290,7 +290,7 @@ mod Space {
 
             self._proposals.write(proposal_id, proposal);
 
-            ProposalUpdated(proposal_id, execution_strategy);
+            ProposalUpdated(proposal_id, @execution_strategy);
         }
 
         fn cancel_proposal(ref self: ContractState, proposal_id: u256) {
@@ -376,11 +376,11 @@ mod Space {
             }  
 
             if NoUpdateArray::should_update((@input).metadata_URI) {
-                MetadataURIUpdated(input.metadata_URI.clone());
+                MetadataURIUpdated(@input.metadata_URI);
             }
 
             if NoUpdateArray::should_update((@input).dao_URI) {
-                DaoURIUpdated(input.dao_URI.clone());
+                DaoURIUpdated(@input.dao_URI);
             }
 
             // if not NO_UPDATE
@@ -388,30 +388,30 @@ mod Space {
                 // TODO: might be possible to remove need to clone by defining the event or setter on a snapshot.
                 // Similarly for all non value types.
                 _set_proposal_validation_strategy(ref self, input.proposal_validation_strategy.clone());
-                ProposalValidationStrategyUpdated(input.proposal_validation_strategy.clone(), input.proposal_validation_strategy_metadata_URI.clone());
+                ProposalValidationStrategyUpdated(@input.proposal_validation_strategy, @input.proposal_validation_strategy_metadata_URI);
             }
 
             if NoUpdateArray::should_update((@input).authenticators_to_add) {
                 _add_authenticators(ref self, input.authenticators_to_add.clone());
-                AuthenticatorsAdded(input.authenticators_to_add.clone());
+                AuthenticatorsAdded(@input.authenticators_to_add);
             }
 
             // if not NO_UPDATE
             if NoUpdateArray::should_update((@input).authenticators_to_remove) {
                 _remove_authenticators(ref self, input.authenticators_to_remove.clone());
-                AuthenticatorsRemoved(input.authenticators_to_remove.clone());
+                AuthenticatorsRemoved(@input.authenticators_to_remove);
             }
 
             // if not NO_UPDATE
             if NoUpdateArray::should_update((@input).voting_strategies_to_add) {
                 _add_voting_strategies(ref self, input.voting_strategies_to_add.clone());
-                VotingStrategiesAdded(input.voting_strategies_to_add.clone(), input.voting_strategies_metadata_URIs_to_add.clone());
+                VotingStrategiesAdded(@input.voting_strategies_to_add, @input.voting_strategies_metadata_URIs_to_add);
             }
 
             // if not NO_UPDATE
             if NoUpdateArray::should_update((@input).voting_strategies_to_remove) {
                 _remove_voting_strategies(ref self, input.voting_strategies_to_remove.clone());
-                        VotingStrategiesRemoved(input.voting_strategies_to_remove.clone());
+                        VotingStrategiesRemoved(@input.voting_strategies_to_remove);
             }
         }
 

--- a/starknet/src/space/space.cairo
+++ b/starknet/src/space/space.cairo
@@ -182,7 +182,7 @@ mod Space {
             // TODO: we use a felt252 for the hash despite felts being discouraged 
             // a new field would just replace the hash. Might be worth casting to a Uint256 though? 
             let execution_payload_hash = poseidon::poseidon_hash_span(
-                execution_strategy.clone().params.span()
+                execution_strategy.params.span()
             );
 
             let proposal = Proposal {

--- a/starknet/src/tests/test_space.cairo
+++ b/starknet/src/tests/test_space.cairo
@@ -21,7 +21,9 @@ mod tests {
     use sx::voting_strategies::vanilla::VanillaVotingStrategy;
     use sx::proposal_validation_strategies::vanilla::VanillaProposalValidationStrategy;
     use sx::tests::mocks::proposal_validation_always_fail::AlwaysFailProposalValidationStrategy;
-    use sx::utils::types::{Strategy, IndexedStrategy, Choice, FinalizationStatus, Proposal, UpdateSettingsCalldataImpl};
+    use sx::utils::types::{
+        Strategy, IndexedStrategy, Choice, FinalizationStatus, Proposal, UpdateSettingsCalldataImpl
+    };
     use sx::utils::constants::{PROPOSE_SELECTOR, VOTE_SELECTOR, UPDATE_PROPOSAL_SELECTOR};
 
     use Space::Space as SpaceImpl;
@@ -299,7 +301,9 @@ mod tests {
         testing::set_caller_address(owner);
         testing::set_contract_address(owner);
         let mut input = UpdateSettingsCalldataImpl::default();
-        input.proposal_validation_strategy = Strategy { address: strategy_address, params: ArrayTrait::<felt252>::new() };
+        input.proposal_validation_strategy = Strategy {
+            address: strategy_address, params: ArrayTrait::<felt252>::new()
+        };
 
         space.update_settings(input);
 

--- a/starknet/src/tests/test_space.cairo
+++ b/starknet/src/tests/test_space.cairo
@@ -21,7 +21,7 @@ mod tests {
     use sx::voting_strategies::vanilla::VanillaVotingStrategy;
     use sx::proposal_validation_strategies::vanilla::VanillaProposalValidationStrategy;
     use sx::tests::mocks::proposal_validation_always_fail::AlwaysFailProposalValidationStrategy;
-    use sx::utils::types::{Strategy, IndexedStrategy, Choice, FinalizationStatus, Proposal};
+    use sx::utils::types::{Strategy, IndexedStrategy, Choice, FinalizationStatus, Proposal, UpdateSettingsCalldataImpl};
     use sx::utils::constants::{PROPOSE_SELECTOR, VOTE_SELECTOR, UPDATE_PROPOSAL_SELECTOR};
 
     use Space::Space as SpaceImpl;
@@ -298,10 +298,10 @@ mod tests {
             .unwrap();
         testing::set_caller_address(owner);
         testing::set_contract_address(owner);
-        space
-            .set_proposal_validation_strategy(
-                Strategy { address: strategy_address, params: ArrayTrait::<felt252>::new() }
-            );
+        let mut input = UpdateSettingsCalldataImpl::default();
+        input.proposal_validation_strategy = Strategy { address: strategy_address, params: ArrayTrait::<felt252>::new() };
+
+        space.update_settings(input);
 
         let mut propose_calldata = array::ArrayTrait::<felt252>::new();
         propose_calldata.append(contract_address_const::<5678>().into());

--- a/starknet/src/utils/types.cairo
+++ b/starknet/src/utils/types.cairo
@@ -648,8 +648,8 @@ impl UpdateSettingsCalldataImpl of UpdateSettingsCalldataTrait {
             authenticators_to_add: NoUpdateArray::no_update(),
             authenticators_to_remove: NoUpdateArray::no_update(),
             voting_strategies_to_add: NoUpdateArray::no_update(),
-            voting_strategies_metadata_URIs_to_add: array::ArrayTrait::new(),
-            voting_strategies_to_remove: array::ArrayTrait::new(),
+            voting_strategies_metadata_URIs_to_add: NoUpdateArray::no_update(),
+            voting_strategies_to_remove: NoUpdateArray::no_update(),
         }
     }
 }

--- a/starknet/src/utils/types.cairo
+++ b/starknet/src/utils/types.cairo
@@ -7,10 +7,10 @@ use option::OptionTrait;
 use clone::Clone;
 use integer::{U8IntoU128};
 use starknet::{
-    ContractAddress, contract_address_const, StorageAccess, StorageBaseAddress, SyscallResult, storage_write_syscall,
-    storage_read_syscall, storage_address_from_base_and_offset, storage_base_address_from_felt252,
-    contract_address::Felt252TryIntoContractAddress, syscalls::deploy_syscall,
-    class_hash::Felt252TryIntoClassHash
+    ContractAddress, contract_address_const, StorageAccess, StorageBaseAddress, SyscallResult,
+    storage_write_syscall, storage_read_syscall, storage_address_from_base_and_offset,
+    storage_base_address_from_felt252, contract_address::Felt252TryIntoContractAddress,
+    syscalls::deploy_syscall, class_hash::Felt252TryIntoClassHash
 };
 use sx::utils::math::pow;
 use array::SpanTrait;
@@ -605,7 +605,7 @@ impl NoUpdateContractAddress of NoUpdateTrait<ContractAddress> {
     }
 
     fn should_update(self: @ContractAddress) -> bool {
-       *self != contract_address_const::<0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048>()
+        *self != contract_address_const::<0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048>()
     }
 }
 
@@ -618,7 +618,8 @@ impl NoUpdateStrategy of NoUpdateTrait<Strategy> {
     }
 
     fn should_update(self: @Strategy) -> bool {
-        *self.address != contract_address_const::<0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048>()
+        *self
+            .address != contract_address_const::<0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048>()
     }
 }
 
@@ -632,7 +633,6 @@ impl NoUpdateArray<T> of NoUpdateTrait<Array<T>> {
         self.len() != 0
     }
 }
-
 
 
 impl UpdateSettingsCalldataImpl of UpdateSettingsCalldataTrait {

--- a/starknet/src/utils/types.cairo
+++ b/starknet/src/utils/types.cairo
@@ -7,12 +7,13 @@ use option::OptionTrait;
 use clone::Clone;
 use integer::{U8IntoU128};
 use starknet::{
-    ContractAddress, StorageAccess, StorageBaseAddress, SyscallResult, storage_write_syscall,
+    ContractAddress, contract_address_const, StorageAccess, StorageBaseAddress, SyscallResult, storage_write_syscall,
     storage_read_syscall, storage_address_from_base_and_offset, storage_base_address_from_felt252,
     contract_address::Felt252TryIntoContractAddress, syscalls::deploy_syscall,
     class_hash::Felt252TryIntoClassHash
 };
 use sx::utils::math::pow;
+use array::SpanTrait;
 
 impl Felt252ArrayIntoU256Array of Into<Array<felt252>, Array<u256>> {
     fn into(self: Array<felt252>) -> Array<u256> {
@@ -532,5 +533,123 @@ impl IndexedStrategyImpl of IndexedStrategyTrait {
             bit_map = bit_map | s;
             i += 1;
         };
+    }
+}
+
+// TODO: move to u32
+#[derive(Clone, Drop, Serde)]
+struct UpdateSettingsCalldata {
+    min_voting_duration: u64,
+    max_voting_duration: u64,
+    voting_delay: u64,
+    metadata_URI: Array<felt252>,
+    dao_URI: Array<felt252>,
+    proposal_validation_strategy: Strategy,
+    proposal_validation_strategy_metadata_URI: Array<felt252>,
+    authenticators_to_add: Array<ContractAddress>,
+    authenticators_to_remove: Array<ContractAddress>,
+    voting_strategies_to_add: Array<Strategy>,
+    voting_strategies_metadata_URIs_to_add: Array<Array<felt252>>,
+    voting_strategies_to_remove: Array<u8>,
+}
+
+trait UpdateSettingsCalldataTrait {
+    fn default() -> UpdateSettingsCalldata;
+}
+
+// Theoretically could derive a value with a proc_macro,
+// since NO_UPDATE values are simply the first x bytes of a hash.
+trait NoUpdateTrait<T> {
+    fn no_update() -> T;
+    fn should_update(self: @T) -> bool;
+}
+
+// Obtained by keccak256 hashing the string "No update", and then taking the corresponding number of bytes.
+// Evaluates to: 0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048ba
+
+impl NoUpdateU32 of NoUpdateTrait<u32> {
+    fn no_update() -> u32 {
+        0xf2cda9b1
+    }
+
+    fn should_update(self: @u32) -> bool {
+        *self != 0xf2cda9b1
+    }
+}
+
+impl NoUpdateU64 of NoUpdateTrait<u64> {
+    fn no_update() -> u64 {
+        0xf2cda9b13ed04e58
+    }
+
+    fn should_update(self: @u64) -> bool {
+        *self != 0xf2cda9b13ed04e58
+    }
+}
+
+impl NoUpdateFelt252 of NoUpdateTrait<felt252> {
+    fn no_update() -> felt252 {
+        // First 248 bits
+        0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048
+    }
+
+    fn should_update(self: @felt252) -> bool {
+        *self != 0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048
+    }
+}
+
+impl NoUpdateContractAddress of NoUpdateTrait<ContractAddress> {
+    fn no_update() -> ContractAddress {
+        // First 248 bits
+        contract_address_const::<0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048>()
+    }
+
+    fn should_update(self: @ContractAddress) -> bool {
+       *self != contract_address_const::<0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048>()
+    }
+}
+
+impl NoUpdateStrategy of NoUpdateTrait<Strategy> {
+    fn no_update() -> Strategy {
+        Strategy {
+            address: contract_address_const::<0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048>(),
+            params: array::ArrayTrait::new(),
+        }
+    }
+
+    fn should_update(self: @Strategy) -> bool {
+        *self.address != contract_address_const::<0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048>()
+    }
+}
+
+// TODO: find a way for "Strings"
+impl NoUpdateArray<T> of NoUpdateTrait<Array<T>> {
+    fn no_update() -> Array<T> {
+        array::ArrayTrait::<T>::new()
+    }
+
+    fn should_update(self: @Array<T>) -> bool {
+        self.len() != 0
+    }
+}
+
+
+
+impl UpdateSettingsCalldataImpl of UpdateSettingsCalldataTrait {
+    fn default() -> UpdateSettingsCalldata {
+        UpdateSettingsCalldata {
+            min_voting_duration: NoUpdateU64::no_update(),
+            max_voting_duration: NoUpdateU64::no_update(),
+            voting_delay: NoUpdateU64::no_update(),
+            metadata_URI: NoUpdateArray::no_update(),
+            dao_URI: NoUpdateArray::no_update(),
+            proposal_validation_strategy: NoUpdateStrategy::no_update(),
+            proposal_validation_strategy_metadata_URI: NoUpdateArray::no_update(),
+            authenticators_to_add: NoUpdateArray::no_update(),
+            authenticators_to_remove: NoUpdateArray::no_update(),
+            voting_strategies_to_add: NoUpdateArray::no_update(),
+            voting_strategies_metadata_URIs_to_add: array::ArrayTrait::new(),
+            voting_strategies_to_remove: array::ArrayTrait::new(),
+        }
     }
 }


### PR DESCRIPTION
1. Removes all `set*` functions
2. Introduces the `update_settings` function, similarly to sx-evm.
3. Updates events to use `@` (snapshot) rather than values.

Closes #427 