### PR TITLE
feat: merkle whitelist

### DIFF
--- a/starknet/src/authenticators/eth_sig.cairo
+++ b/starknet/src/authenticators/eth_sig.cairo
@@ -47,7 +47,7 @@ mod EthSigAuthenticator {
     use clone::Clone;
     use sx::space::space::{ISpaceDispatcher, ISpaceDispatcherTrait};
     use sx::types::{Strategy, IndexedStrategy, Choice, UserAddress};
-    use sx::utils::{signatures, LegacyHashEthAddress};
+    use sx::utils::{signatures, legacy_hash::LegacyHashEthAddress};
 
     #[storage]
     struct Storage {

--- a/starknet/src/space/space.cairo
+++ b/starknet/src/space/space.cairo
@@ -60,7 +60,6 @@ mod Space {
     use array::{ArrayTrait, SpanTrait};
     use clone::Clone;
     use option::OptionTrait;
-    use hash::LegacyHash;
     use traits::Into;
 
     use sx::interfaces::{

--- a/starknet/src/space/space.cairo
+++ b/starknet/src/space/space.cairo
@@ -75,6 +75,7 @@ mod Space {
         NoUpdateStrategy, NoUpdateArray
     };
     use sx::utils::bits::BitSetter;
+    use sx::utils::legacy_hash::LegacyHashChoice;
     use sx::external::ownable::Ownable;
 
     #[storage]

--- a/starknet/src/tests.cairo
+++ b/starknet/src/tests.cairo
@@ -1,7 +1,7 @@
 mod test_merkle_whitelist;
-// mod test_factory;
-// mod test_space;
-// mod test_upgrade;
+mod test_factory;
+mod test_space;
+mod test_upgrade;
 
 mod mocks;
 mod setup;

--- a/starknet/src/tests.cairo
+++ b/starknet/src/tests.cairo
@@ -1,6 +1,7 @@
-mod test_space;
-mod test_factory;
-mod test_upgrade;
+mod test_merkle_whitelist;
+// mod test_factory;
+// mod test_space;
+// mod test_upgrade;
 
 mod mocks;
 mod setup;

--- a/starknet/src/tests/test_merkle_whitelist.cairo
+++ b/starknet/src/tests/test_merkle_whitelist.cairo
@@ -1,0 +1,360 @@
+use sx::interfaces::i_voting_strategy::IVotingStrategyDispatcherTrait;
+use core::clone::Clone;
+use sx::utils::merkle::Hash;
+#[cfg(test)]
+mod assert_valid_proof {
+    use sx::tests::setup::setup::setup::{setup, deploy};
+    use debug::PrintTrait;
+    use array::{ArrayTrait, SpanTrait};
+    use option::OptionTrait;
+    use sx::utils::merkle::{Leaf, assert_valid_proof, Hash};
+    use starknet::{contract_address_const, contract_address_try_from_felt252};
+    use clone::Clone;
+    use traits::Into;
+    use hash::LegacyHash;
+    use serde::Serde;
+
+    impl SpanIntoArray<T, impl TClone: Clone<T>, impl TDrop: Drop<T>> of Into<Span<T>, Array<T>> {
+        fn into(self: Span<T>) -> Array<T> {
+            let mut self = self;
+            let mut output = ArrayTrait::<T>::new();
+            loop {
+                match self.pop_front() {
+                    Option::Some(val) => output.append(val.clone()),
+                    Option::None => {
+                        break;
+                    }
+                };
+            };
+            output
+        }
+    }
+
+    fn get_proof(mut values: Span<felt252>, mut index: usize) -> Array<felt252> {
+        let mut proof = ArrayTrait::new();
+
+        loop {
+            if values.len() == 1 {
+                break;
+            }
+
+            if values.len() % 2 != 0 {
+                let mut cpy = values.into();
+                cpy.append(0_felt252); // append 0 because of odd length
+                values = cpy.span();
+            }
+
+            let next_level = get_next_level(values);
+
+            let mut index_parent = 0_usize;
+            let mut i = 0_usize;
+            loop {
+                if i == values.len() {
+                    break;
+                }
+                if i == index {
+                    index_parent = i / 2;
+                    if i % 2 == 0 {
+                        proof.append(*values.at(index + 1));
+                    } else {
+                        proof.append(*values.at(index - 1));
+                    }
+                }
+                i += 1;
+            };
+            values = next_level.span();
+            index = index_parent;
+        };
+        proof
+    }
+
+    fn generate_merkle_root(mut values: Span<felt252>) -> felt252 {
+        if values.len() == 1 {
+            return *values.pop_front().unwrap();
+        }
+
+        if values.len() % 2 != 0 {
+            let mut cpy = values.into();
+            cpy.append(0_felt252); // append 0 because of odd length
+            values = cpy.span();
+        }
+
+        let next_level = get_next_level(values);
+        generate_merkle_root(next_level.span())
+    }
+
+    fn get_next_level(mut values: Span<felt252>) -> Array<felt252> {
+        let mut next_level = ArrayTrait::<felt252>::new();
+        loop {
+            match values.pop_front() {
+                Option::Some(a) => {
+                    match values.pop_front() {
+                        Option::Some(b) => {
+                            // compare
+                            let a_: u256 = (*a).into();
+                            let b_: u256 = (*b).into();
+                            if a_ > b_ {
+                                let node = LegacyHash::hash(*a, *b);
+                                next_level.append(node);
+                            } else {
+                                let node = LegacyHash::hash(*b, *a);
+                                next_level.append(node);
+                            }
+                        },
+                        Option::None => panic_with_felt252('Incorrect array length'),
+                    }
+                },
+                Option::None => {
+                    break;
+                }
+            };
+        };
+        next_level
+    }
+
+    fn generate_merkle_data(members: Span<Leaf>) -> Array<felt252> {
+        let mut members_ = members;
+        let mut output = ArrayTrait::<felt252>::new();
+        loop {
+            match members_.pop_front() {
+                Option::Some(leaf) => {
+                    output.append(leaf.hash());
+                },
+                Option::None => {
+                    break;
+                },
+            };
+        };
+        output
+    }
+
+    fn generate_n_members(n: usize) -> Array<Leaf> {
+        let mut members = ArrayTrait::<Leaf>::new();
+        let mut i = 1_usize;
+        loop {
+            if i >= n + 1 {
+                break;
+            }
+            members
+                .append(
+                    Leaf {
+                        address: contract_address_try_from_felt252(i.into()).unwrap(),
+                        voting_power: i.into()
+                    }
+                );
+            i += 1;
+        };
+        members
+    }
+
+    fn verify_all_members(members: Span<Leaf>) {
+        let merkle_data = generate_merkle_data(members);
+        let root = generate_merkle_root(merkle_data.span());
+        let mut index = 0;
+        loop {
+            let proof = get_proof(merkle_data.span(), index);
+            if index == members.len() {
+                break;
+            }
+            assert_valid_proof(root, *members.at(index), proof.span());
+            index += 1;
+        }
+    }
+
+    #[test]
+    #[available_gas(10000000)]
+    fn one_member() {
+        let mut members = generate_n_members(1);
+        verify_all_members(members.span());
+    }
+
+    #[test]
+    #[available_gas(10000000)]
+    fn two_members() {
+        let members = generate_n_members(2);
+        verify_all_members(members.span());
+    }
+
+    #[test]
+    #[available_gas(10000000)]
+    fn three_members() {
+        let members = generate_n_members(3);
+        verify_all_members(members.span());
+    }
+
+    #[test]
+    #[available_gas(10000000)]
+    fn four_members() {
+        let members = generate_n_members(4);
+        verify_all_members(members.span());
+    }
+
+    #[test]
+    #[available_gas(1000000000)]
+    fn one_hundred_members() {
+        let members = generate_n_members(100);
+        verify_all_members(members.span());
+    }
+
+    #[test]
+    #[available_gas(1000000000)]
+    fn one_hundred_and_one_members() {
+        let members = generate_n_members(101);
+        verify_all_members(members.span());
+    }
+
+    #[test]
+    #[available_gas(1000000000)]
+    #[should_panic(expected: ('Merkle: Invalid proof', ))]
+    fn no_leaf() {
+        let root = 0;
+        let leaf = Leaf { address: contract_address_const::<0>(), voting_power: 0 };
+        let proof = ArrayTrait::new();
+        assert_valid_proof(root, leaf, proof.span());
+    }
+
+    #[test]
+    #[available_gas(10000000)]
+    #[should_panic(expected: ('Merkle: Invalid proof', ))]
+    fn invalid_extra_node() {
+        let mut members = ArrayTrait::new();
+        members.append(Leaf { address: contract_address_const::<5>(), voting_power: 5 });
+        members.append(Leaf { address: contract_address_const::<4>(), voting_power: 4 });
+        members.append(Leaf { address: contract_address_const::<3>(), voting_power: 3 });
+        members.append(Leaf { address: contract_address_const::<2>(), voting_power: 2 });
+        members.append(Leaf { address: contract_address_const::<1>(), voting_power: 1 });
+        let merkle_data = generate_merkle_data(members.span());
+
+        let root = generate_merkle_root(merkle_data.span());
+        let index = 2;
+        let mut proof = get_proof(merkle_data.span(), index);
+        proof.append(0x1337); // Adding a useless node
+        assert_valid_proof(root, *members.at(index), proof.span());
+    }
+
+    // Replaces the first element of `arr` with `value`.
+    fn replace_first_element<T, impl TDrop: Drop<T>, impl TCopy: Copy<T>>(
+        mut arr: Span<T>, value: T
+    ) -> Array<T> {
+        let mut output = ArrayTrait::new();
+        output.append(value);
+
+        arr.pop_front(); // remove first element
+        loop {
+            match arr.pop_front() {
+                Option::Some(v) => output.append(*v),
+                Option::None => {
+                    break;
+                },
+            };
+        };
+        output
+    }
+
+    #[test]
+    #[available_gas(10000000)]
+    #[should_panic(expected: ('Merkle: Invalid proof', ))]
+    fn invalid_proof() {
+        let mut members = ArrayTrait::new();
+        members.append(Leaf { address: contract_address_const::<5>(), voting_power: 5 });
+        members.append(Leaf { address: contract_address_const::<4>(), voting_power: 4 });
+        members.append(Leaf { address: contract_address_const::<3>(), voting_power: 3 });
+        members.append(Leaf { address: contract_address_const::<2>(), voting_power: 2 });
+        members.append(Leaf { address: contract_address_const::<1>(), voting_power: 1 });
+        let merkle_data = generate_merkle_data(members.span());
+
+        let root = generate_merkle_root(merkle_data.span());
+        let index = 2;
+        let proof = get_proof(merkle_data.span(), index);
+        let fake_proof = replace_first_element(proof.span(), 0x1337);
+
+        assert_valid_proof(root, *members.at(index), fake_proof.span());
+    }
+}
+
+#[cfg(test)]
+mod merkle_whitelist_voting_power {
+    use array::ArrayTrait;
+    use sx::utils::merkle::Leaf;
+    use super::assert_valid_proof::{
+        generate_merkle_root, generate_n_members, generate_merkle_data, get_proof
+    };
+    use sx::voting_strategies::merkle_whitelist::{MerkleWhitelistVotingStrategy};
+    use sx::interfaces::IVotingStrategy;
+    use starknet::syscalls::deploy_syscall;
+    use starknet::SyscallResult;
+    use result::ResultTrait;
+    use option::OptionTrait;
+    use traits::TryInto;
+    use sx::interfaces::{IVotingStrategyDispatcher, IVotingStrategyDispatcherTrait};
+    use serde::Serde;
+
+
+    #[test]
+    #[available_gas(1000000000)]
+    fn one_hundred_members() {
+        let members = generate_n_members(20);
+
+        let (contract, _) = deploy_syscall(
+            MerkleWhitelistVotingStrategy::TEST_CLASS_HASH.try_into().unwrap(),
+            0,
+            array::ArrayTrait::<felt252>::new().span(),
+            false,
+        )
+            .unwrap();
+        let voting_strategy = IVotingStrategyDispatcher { contract_address: contract };
+        let timestamp = 0x1234;
+        let index = 2;
+        let leaf = *members.at(index);
+        let voter = leaf.address;
+
+        let merkle_data = generate_merkle_data(members.span());
+        let root = generate_merkle_root(merkle_data.span());
+        let proof = get_proof(merkle_data.span(), index);
+
+        let mut params = ArrayTrait::<felt252>::new();
+        root.serialize(ref params);
+
+        let mut user_params = ArrayTrait::<felt252>::new();
+        leaf.serialize(ref user_params);
+        proof.serialize(ref user_params);
+
+        voting_strategy.get_voting_power(timestamp, voter, params, user_params);
+    }
+
+    #[test]
+    #[available_gas(1000000000)]
+    #[should_panic(expected: ('Merkle: Invalid proof', 'ENTRYPOINT_FAILED'))]
+    fn lying_voting_power() {
+        let members = generate_n_members(20);
+
+        let (contract, _) = deploy_syscall(
+            MerkleWhitelistVotingStrategy::TEST_CLASS_HASH.try_into().unwrap(),
+            0,
+            array::ArrayTrait::<felt252>::new().span(),
+            false,
+        )
+            .unwrap();
+        let voting_strategy = IVotingStrategyDispatcher { contract_address: contract };
+        let timestamp = 0x1234;
+        let index = 2;
+        let leaf = *members.at(index);
+        let voter = leaf.address;
+
+        let merkle_data = generate_merkle_data(members.span());
+        let root = generate_merkle_root(merkle_data.span());
+        let proof = get_proof(merkle_data.span(), index);
+
+        let mut params = ArrayTrait::<felt252>::new();
+        root.serialize(ref params);
+
+        let mut user_params = ArrayTrait::<felt252>::new();
+        let fake_leaf = Leaf {
+            address: leaf.address, voting_power: leaf.voting_power + 1, 
+        }; // lying about voting power here
+        fake_leaf.serialize(ref user_params);
+        proof.serialize(ref user_params);
+
+        voting_strategy.get_voting_power(timestamp, voter, params, user_params);
+    }
+}

--- a/starknet/src/tests/test_merkle_whitelist.cairo
+++ b/starknet/src/tests/test_merkle_whitelist.cairo
@@ -1,18 +1,13 @@
-use sx::interfaces::i_voting_strategy::IVotingStrategyDispatcherTrait;
-use core::clone::Clone;
-use sx::utils::merkle::Hash;
 #[cfg(test)]
-mod assert_valid_proof {
-    use sx::tests::setup::setup::setup::{setup, deploy};
-    use debug::PrintTrait;
+mod merkle_utils {
     use array::{ArrayTrait, SpanTrait};
-    use option::OptionTrait;
-    use sx::utils::merkle::{Leaf, assert_valid_proof, Hash};
-    use starknet::{contract_address_const, contract_address_try_from_felt252};
     use clone::Clone;
     use traits::Into;
+    use result::ResultTrait;
+    use option::OptionTrait;
     use hash::LegacyHash;
-    use serde::Serde;
+    use sx::utils::merkle::{Leaf, Hash};
+    use starknet::contract_address_try_from_felt252;
 
     impl SpanIntoArray<T, impl TClone: Clone<T>, impl TDrop: Drop<T>> of Into<Span<T>, Array<T>> {
         fn into(self: Span<T>) -> Array<T> {
@@ -146,6 +141,21 @@ mod assert_valid_proof {
         };
         members
     }
+}
+#[cfg(test)]
+mod assert_valid_proof {
+    use sx::tests::setup::setup::setup::{setup, deploy};
+    use array::{ArrayTrait, SpanTrait};
+    use option::OptionTrait;
+    use sx::utils::merkle::{Leaf, assert_valid_proof, Hash};
+    use starknet::{contract_address_const, contract_address_try_from_felt252};
+    use clone::Clone;
+    use traits::Into;
+    use hash::LegacyHash;
+    use serde::Serde;
+    use super::merkle_utils::{
+        generate_n_members, generate_merkle_data, generate_merkle_root, get_proof
+    };
 
     fn verify_all_members(members: Span<Leaf>) {
         let merkle_data = generate_merkle_data(members);
@@ -276,7 +286,7 @@ mod assert_valid_proof {
 mod merkle_whitelist_voting_power {
     use array::ArrayTrait;
     use sx::utils::merkle::Leaf;
-    use super::assert_valid_proof::{
+    use super::merkle_utils::{
         generate_merkle_root, generate_n_members, generate_merkle_data, get_proof
     };
     use sx::voting_strategies::merkle_whitelist::{MerkleWhitelistVotingStrategy};

--- a/starknet/src/tests/test_merkle_whitelist.cairo
+++ b/starknet/src/tests/test_merkle_whitelist.cairo
@@ -130,6 +130,7 @@ mod merkle_utils {
 
     // Generates n members with voting power 1, 2, 3, and 
     // address 1, 2, 3, ...
+    // Even members will be Ethereum addresses and odd members will be Starknet addresses.
     fn generate_n_members(n: usize) -> Array<Leaf> {
         let mut members = ArrayTrait::<Leaf>::new();
         let mut i = 1_usize;
@@ -137,15 +138,14 @@ mod merkle_utils {
             if i >= n + 1 {
                 break;
             }
-            members
-                .append(
-                    Leaf {
-                        address: UserAddress::Starknet(
-                            contract_address_try_from_felt252(i.into()).unwrap()
-                        ),
-                        voting_power: i.into()
-                    }
-                );
+            let mut address = UserAddress::Custom(0);
+            if i % 2 == 0 {
+                address = UserAddress::Ethereum(starknet::EthAddress { address: i.into() });
+            } else {
+                address =
+                    UserAddress::Starknet(contract_address_try_from_felt252(i.into()).unwrap());
+            }
+            members.append(Leaf { address: address, voting_power: i.into() });
             i += 1;
         };
         members

--- a/starknet/src/types/choice.cairo
+++ b/starknet/src/types/choice.cairo
@@ -2,7 +2,6 @@ use serde::Serde;
 use traits::Into;
 use hash::LegacyHash;
 
-
 #[derive(Copy, Drop, Serde)]
 enum Choice {
     Against: (),
@@ -23,11 +22,5 @@ impl ChoiceIntoU8 of Into<Choice, u8> {
 impl ChoiceIntoU256 of Into<Choice, u256> {
     fn into(self: Choice) -> u256 {
         ChoiceIntoU8::into(self).into()
-    }
-}
-
-impl LegacyHashChoice of LegacyHash<Choice> {
-    fn hash(state: felt252, value: Choice) -> felt252 {
-        LegacyHash::hash(state, ChoiceIntoU8::into(value))
     }
 }

--- a/starknet/src/types/strategy.cairo
+++ b/starknet/src/types/strategy.cairo
@@ -5,7 +5,6 @@ use option::OptionTrait;
 use clone::Clone;
 use result::ResultTrait;
 use traits::TryInto;
-use hash::LegacyHash;
 use starknet::{StorageBaseAddress, Store, SyscallResult};
 
 #[derive(Clone, Drop, Option, Serde, starknet::Store)]

--- a/starknet/src/types/user_address.cairo
+++ b/starknet/src/types/user_address.cairo
@@ -1,8 +1,8 @@
 use starknet::{ContractAddress, EthAddress};
 use traits::{PartialEq, TryInto, Into};
-use hash::LegacyHash;
 use serde::Serde;
 use array::ArrayTrait;
+use sx::utils::legacy_hash::LegacyHashUserAddress;
 
 #[derive(Copy, Drop, Serde, PartialEq, starknet::Store)]
 enum UserAddress {
@@ -12,16 +12,6 @@ enum UserAddress {
     Ethereum: EthAddress,
     // Custom address type to provide compatibility with any address that can be represented as a u256.
     Custom: u256
-}
-
-impl LegacyHashUserAddress of LegacyHash<UserAddress> {
-    fn hash(state: felt252, value: UserAddress) -> felt252 {
-        match value {
-            UserAddress::Starknet(address) => LegacyHash::<felt252>::hash(state, address.into()),
-            UserAddress::Ethereum(address) => LegacyHash::<felt252>::hash(state, address.into()),
-            UserAddress::Custom(address) => LegacyHash::<u256>::hash(state, address),
-        }
-    }
 }
 
 trait UserAddressTrait {

--- a/starknet/src/utils.cairo
+++ b/starknet/src/utils.cairo
@@ -5,8 +5,7 @@ mod constants;
 mod felt_arr_to_uint_arr;
 use felt_arr_to_uint_arr::Felt252ArrayIntoU256Array;
 
-mod legacy_hash_eth_address;
-use legacy_hash_eth_address::LegacyHashEthAddress;
+mod legacy_hash;
 
 mod math;
 mod merkle;

--- a/starknet/src/utils.cairo
+++ b/starknet/src/utils.cairo
@@ -6,6 +6,7 @@ mod felt_arr_to_uint_arr;
 use felt_arr_to_uint_arr::Felt252ArrayIntoU256Array;
 
 mod math;
+mod merkle;
 
 mod single_slot_proof;
 

--- a/starknet/src/utils/legacy_hash.cairo
+++ b/starknet/src/utils/legacy_hash.cairo
@@ -1,0 +1,47 @@
+use hash::LegacyHash;
+use traits::Into;
+use starknet::EthAddress;
+use sx::types::{Choice, UserAddress};
+use array::{ArrayTrait, SpanTrait};
+
+impl LegacyHashChoice of LegacyHash<Choice> {
+    fn hash(state: felt252, value: Choice) -> felt252 {
+        let choice: u8 = value.into();
+        LegacyHash::hash(state, choice)
+    }
+}
+
+impl LegacyHashEthAddress of LegacyHash<EthAddress> {
+    fn hash(state: felt252, value: EthAddress) -> felt252 {
+        LegacyHash::<felt252>::hash(state, value.into())
+    }
+}
+
+impl LegacyHashSpan of LegacyHash<Span<felt252>> {
+    fn hash(mut state: felt252, mut value: Span<felt252>) -> felt252 {
+        let len = value.len();
+        loop {
+            match value.pop_front() {
+                Option::Some(current) => {
+                    state = LegacyHash::hash(state, *current);
+                },
+                Option::None => {
+                    break;
+                },
+            };
+        };
+        LegacyHash::hash(
+            state, len
+        ) // append the length to conform to computeHashOnElements in starknet.js
+    }
+}
+
+impl LegacyHashUserAddress of LegacyHash<UserAddress> {
+    fn hash(state: felt252, value: UserAddress) -> felt252 {
+        match value {
+            UserAddress::Starknet(address) => LegacyHash::<felt252>::hash(state, address.into()),
+            UserAddress::Ethereum(address) => LegacyHash::<felt252>::hash(state, address.into()),
+            UserAddress::Custom(address) => LegacyHash::<u256>::hash(state, address),
+        }
+    }
+}

--- a/starknet/src/utils/legacy_hash_eth_address.cairo
+++ b/starknet/src/utils/legacy_hash_eth_address.cairo
@@ -1,9 +1,0 @@
-use hash::LegacyHash;
-use traits::Into;
-use starknet::EthAddress;
-
-impl LegacyHashEthAddress of LegacyHash<EthAddress> {
-    fn hash(state: felt252, value: EthAddress) -> felt252 {
-        LegacyHash::<felt252>::hash(state, value.into())
-    }
-}

--- a/starknet/src/utils/merkle.cairo
+++ b/starknet/src/utils/merkle.cairo
@@ -2,14 +2,14 @@ use core::traits::Into;
 use array::{ArrayTrait, Span, SpanTrait};
 use option::OptionTrait;
 use serde::Serde;
-use starknet::ContractAddress;
+use sx::types::UserAddress;
 use clone::Clone;
 use hash::{LegacyHash};
 use debug::PrintTrait;
 
 #[derive(Copy, Clone, Drop, Serde)]
 struct Leaf {
-    address: ContractAddress, // use UserAddress
+    address: UserAddress,
     voting_power: u256,
 }
 

--- a/starknet/src/utils/merkle.cairo
+++ b/starknet/src/utils/merkle.cairo
@@ -6,6 +6,7 @@ use sx::types::UserAddress;
 use clone::Clone;
 use hash::{LegacyHash};
 use debug::PrintTrait;
+use sx::utils::legacy_hash::LegacyHashSpan;
 
 /// Leaf struct for the merkle tree
 #[derive(Copy, Clone, Drop, Serde)]
@@ -16,25 +17,6 @@ struct Leaf {
 
 trait Hash<T> {
     fn hash(self: @T) -> felt252;
-}
-
-impl LegacyHashSpan of LegacyHash<Span<felt252>> {
-    fn hash(mut state: felt252, mut value: Span<felt252>) -> felt252 {
-        let len = value.len();
-        loop {
-            match value.pop_front() {
-                Option::Some(current) => {
-                    state = LegacyHash::hash(state, *current);
-                },
-                Option::None => {
-                    break;
-                },
-            };
-        };
-        LegacyHash::hash(
-            state, len
-        ) // append the length to conform to computeHashOnElements in starknet.js
-    }
 }
 
 impl HashSerde<T, impl TSerde: Serde<T>> of Hash<T> {

--- a/starknet/src/utils/merkle.cairo
+++ b/starknet/src/utils/merkle.cairo
@@ -7,6 +7,7 @@ use clone::Clone;
 use hash::{LegacyHash};
 use debug::PrintTrait;
 
+/// Leaf struct for the merkle tree
 #[derive(Copy, Clone, Drop, Serde)]
 struct Leaf {
     address: UserAddress,
@@ -30,11 +31,13 @@ impl LegacyHashSpan of LegacyHash<Span<felt252>> {
                 },
             };
         };
-        LegacyHash::hash(state, len) // append the length to conform to computeHashOnElements
+        LegacyHash::hash(
+            state, len
+        ) // append the length to conform to computeHashOnElements in starknet.js
     }
 }
 
-impl HashType<T, impl TSerde: Serde<T>> of Hash<T> {
+impl HashSerde<T, impl TSerde: Serde<T>> of Hash<T> {
     fn hash(self: @T) -> felt252 {
         let mut serialized = ArrayTrait::new();
         Serde::<T>::serialize(self, ref serialized);
@@ -43,12 +46,14 @@ impl HashType<T, impl TSerde: Serde<T>> of Hash<T> {
     }
 }
 
+/// Asserts that the given proof is valid for the given leaf and root.
 fn assert_valid_proof(root: felt252, leaf: Leaf, proof: Span<felt252>) {
     let leaf_node = leaf.hash();
     let computed_root = _compute_merkle_root(leaf_node, proof);
     assert(computed_root == root, 'Merkle: Invalid proof');
 }
 
+/// Internal helper function that computes the merkle root, given a leaf node and a proof.
 fn _compute_merkle_root(mut current: felt252, proof: Span<felt252>) -> felt252 {
     let mut proof = proof;
     loop {

--- a/starknet/src/utils/merkle.cairo
+++ b/starknet/src/utils/merkle.cairo
@@ -1,0 +1,69 @@
+use core::traits::Into;
+use array::{ArrayTrait, Span, SpanTrait};
+use option::OptionTrait;
+use serde::Serde;
+use starknet::ContractAddress;
+use clone::Clone;
+use hash::{LegacyHash};
+use debug::PrintTrait;
+
+#[derive(Copy, Clone, Drop, Serde)]
+struct Leaf {
+    address: ContractAddress, // use UserAddress
+    voting_power: u256,
+}
+
+trait Hash<T> {
+    fn hash(self: @T) -> felt252;
+}
+
+impl LegacyHashSpan of LegacyHash<Span<felt252>> {
+    fn hash(mut state: felt252, mut value: Span<felt252>) -> felt252 {
+        let len = value.len();
+        loop {
+            match value.pop_front() {
+                Option::Some(current) => {
+                    state = LegacyHash::hash(state, *current);
+                },
+                Option::None => {
+                    break;
+                },
+            };
+        };
+        LegacyHash::hash(state, len) // append the length to conform to computeHashOnElements
+    }
+}
+
+impl HashType<T, impl TSerde: Serde<T>> of Hash<T> {
+    fn hash(self: @T) -> felt252 {
+        let mut serialized = ArrayTrait::new();
+        Serde::<T>::serialize(self, ref serialized);
+        let hashed = LegacyHash::hash(0, serialized.span());
+        hashed
+    }
+}
+
+fn assert_valid_proof(root: felt252, leaf: Leaf, proof: Span<felt252>) {
+    let leaf_node = leaf.hash();
+    let computed_root = _compute_merkle_root(leaf_node, proof);
+    assert(computed_root == root, 'Merkle: Invalid proof');
+}
+
+fn _compute_merkle_root(mut current: felt252, proof: Span<felt252>) -> felt252 {
+    let mut proof = proof;
+    loop {
+        match proof.pop_front() {
+            Option::Some(val) => {
+                let p_u256: u256 = (*val).into(); // Needed for type annotation
+                if current.into() >= p_u256 {
+                    current = LegacyHash::hash(current, *val);
+                } else {
+                    current = LegacyHash::hash(*val, current);
+                };
+            },
+            Option::None => {
+                break current;
+            },
+        };
+    }
+}

--- a/starknet/src/voting_strategies.cairo
+++ b/starknet/src/voting_strategies.cairo
@@ -1,3 +1,5 @@
 mod vanilla;
 
 mod eth_balance_of;
+
+mod merkle_whitelist;

--- a/starknet/src/voting_strategies/merkle_whitelist.cairo
+++ b/starknet/src/voting_strategies/merkle_whitelist.cairo
@@ -1,0 +1,38 @@
+#[starknet::contract]
+mod MerkleWhitelistVotingStrategy {
+    use sx::interfaces::IVotingStrategy;
+    use serde::Serde;
+    use starknet::ContractAddress;
+    use array::{ArrayTrait, Span, SpanTrait};
+    use option::OptionTrait;
+    use sx::utils::merkle::{assert_valid_proof, Leaf};
+    use debug::PrintTrait;
+
+    #[storage]
+    struct Storage {}
+
+    #[external(v0)]
+    impl MerkleWhitelistImpl of IVotingStrategy<ContractState> {
+        fn get_voting_power(
+            self: @ContractState,
+            timestamp: u64,
+            voter: ContractAddress,
+            params: Array<felt252>,
+            user_params: Array<felt252>,
+        ) -> u256 {
+            let LEAF_SIZE = 3;
+            let cache = user_params.span(); // cache
+
+            let mut leaf_raw = cache.slice(0, LEAF_SIZE);
+            let leaf = Serde::<Leaf>::deserialize(ref leaf_raw).unwrap();
+
+            let mut proofs_raw = cache.slice(LEAF_SIZE, cache.len() - LEAF_SIZE);
+            let proofs = Serde::<Array<felt252>>::deserialize(ref proofs_raw).unwrap();
+
+            let root = *params.at(0); // no need to deserialize because it's a simple value
+
+            assert_valid_proof(root, leaf, proofs.span());
+            leaf.voting_power
+        }
+    }
+}

--- a/starknet/src/voting_strategies/merkle_whitelist.cairo
+++ b/starknet/src/voting_strategies/merkle_whitelist.cairo
@@ -17,8 +17,8 @@ mod MerkleWhitelistVotingStrategy {
             self: @ContractState,
             timestamp: u64,
             voter: ContractAddress,
-            params: Array<felt252>,
-            user_params: Array<felt252>,
+            params: Array<felt252>, // [root]
+            user_params: Array<felt252>, // [leaf, proofs]
         ) -> u256 {
             let LEAF_SIZE = 3;
             let cache = user_params.span(); // cache

--- a/starknet/src/voting_strategies/merkle_whitelist.cairo
+++ b/starknet/src/voting_strategies/merkle_whitelist.cairo
@@ -8,6 +8,8 @@ mod MerkleWhitelistVotingStrategy {
     use sx::utils::merkle::{assert_valid_proof, Leaf};
     use debug::PrintTrait;
 
+    const LEAF_SIZE: usize = 4; // Serde::<Leaf>::serialize().len()
+
     #[storage]
     struct Storage {}
 
@@ -20,7 +22,6 @@ mod MerkleWhitelistVotingStrategy {
             params: Array<felt252>, // [root]
             user_params: Array<felt252>, // [Serde(leaf), Serde(proofs)]
         ) -> u256 {
-            let LEAF_SIZE = 4; // Serde::<Leaf>::serialize().len()
             let cache = user_params.span(); // cache
 
             let mut leaf_raw = cache.slice(0, LEAF_SIZE);

--- a/starknet/src/voting_strategies/merkle_whitelist.cairo
+++ b/starknet/src/voting_strategies/merkle_whitelist.cairo
@@ -2,7 +2,7 @@
 mod MerkleWhitelistVotingStrategy {
     use sx::interfaces::IVotingStrategy;
     use serde::Serde;
-    use starknet::ContractAddress;
+    use sx::types::UserAddress;
     use array::{ArrayTrait, Span, SpanTrait};
     use option::OptionTrait;
     use sx::utils::merkle::{assert_valid_proof, Leaf};
@@ -16,11 +16,11 @@ mod MerkleWhitelistVotingStrategy {
         fn get_voting_power(
             self: @ContractState,
             timestamp: u64,
-            voter: ContractAddress,
+            voter: UserAddress,
             params: Array<felt252>, // [root]
-            user_params: Array<felt252>, // [leaf, proofs]
+            user_params: Array<felt252>, // [Serde(leaf), Serde(proofs)]
         ) -> u256 {
-            let LEAF_SIZE = 3;
+            let LEAF_SIZE = 4; // Serde::<Leaf>::serialize().len()
             let cache = user_params.span(); // cache
 
             let mut leaf_raw = cache.slice(0, LEAF_SIZE);


### PR DESCRIPTION
Reimplementation of the previous merkle whitelist (https://github.com/snapshot-labs/sx-starknet/blob/f81bab3a1de328d8ee657b8a47678f8dccf4b468/contracts/starknet/VotingStrategies/MerkleWhitelist.cairo)

The main difference here is that the address is a `UserAddress` (2 felt 252) and not a `felt252` anymore.


Also comes with utils for proof creation in cairo (in `sx::test_merkle_whitelist::merkle_utils`)

Closes #468 