### PR TITLE
refactor: time tracking

### DIFF
--- a/starknet/src/execution_strategies/simple_quorum.cairo
+++ b/starknet/src/execution_strategies/simple_quorum.cairo
@@ -1,5 +1,8 @@
+use core::traits::TryInto;
 #[starknet::contract]
 mod SimpleQuorumExecutionStrategy {
+    use traits::TryInto;
+    use option::OptionTrait;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
     use starknet::info;
@@ -27,7 +30,7 @@ mod SimpleQuorumExecutionStrategy {
         let accepted = _quorum_reached(self._quorum.read(), votes_for, votes_against, votes_abstain)
             & _supported(votes_for, votes_against);
 
-        let block_number = info::get_block_number();
+        let block_number = info::get_block_number().try_into().unwrap();
         if *proposal.finalization_status == FinalizationStatus::Cancelled(()) {
             ProposalStatus::Cancelled(())
         } else if *proposal.finalization_status == FinalizationStatus::Executed(()) {

--- a/starknet/src/execution_strategies/simple_quorum.cairo
+++ b/starknet/src/execution_strategies/simple_quorum.cairo
@@ -27,16 +27,16 @@ mod SimpleQuorumExecutionStrategy {
         let accepted = _quorum_reached(self._quorum.read(), votes_for, votes_against, votes_abstain)
             & _supported(votes_for, votes_against);
 
-        let timestamp = info::get_block_timestamp();
+        let block_number = info::get_block_number();
         if *proposal.finalization_status == FinalizationStatus::Cancelled(()) {
             ProposalStatus::Cancelled(())
         } else if *proposal.finalization_status == FinalizationStatus::Executed(()) {
             ProposalStatus::Executed(())
-        } else if timestamp < *proposal.start_timestamp {
+        } else if block_number < *proposal.start_block_number {
             ProposalStatus::VotingDelay(())
-        } else if timestamp < *proposal.min_end_timestamp {
+        } else if block_number < *proposal.min_end_block_number {
             ProposalStatus::VotingPeriod(())
-        } else if timestamp < *proposal.max_end_timestamp {
+        } else if block_number < *proposal.max_end_block_number {
             if accepted {
                 ProposalStatus::VotingPeriodAccepted(())
             } else {

--- a/starknet/src/interfaces/i_voting_strategy.cairo
+++ b/starknet/src/interfaces/i_voting_strategy.cairo
@@ -5,7 +5,7 @@ use sx::types::UserAddress;
 trait IVotingStrategy<TContractState> {
     fn get_voting_power(
         self: @TContractState,
-        timestamp: u64,
+        timestamp: u32,
         voter: UserAddress,
         params: Array<felt252>,
         user_params: Array<felt252>,

--- a/starknet/src/interfaces/i_voting_strategy.cairo
+++ b/starknet/src/interfaces/i_voting_strategy.cairo
@@ -5,7 +5,7 @@ use sx::types::UserAddress;
 trait IVotingStrategy<TContractState> {
     fn get_voting_power(
         self: @TContractState,
-        timestamp: u32,
+        block_number: u32,
         voter: UserAddress,
         params: Array<felt252>,
         user_params: Array<felt252>,

--- a/starknet/src/space/space.cairo
+++ b/starknet/src/space/space.cairo
@@ -1,3 +1,4 @@
+use core::traits::TryInto;
 use core::traits::Destruct;
 use starknet::{ClassHash, ContractAddress};
 use sx::types::{UserAddress, Strategy, Proposal, IndexedStrategy, Choice, UpdateSettingsCalldata};
@@ -6,10 +7,10 @@ use sx::types::{UserAddress, Strategy, Proposal, IndexedStrategy, Choice, Update
 trait ISpace<TContractState> {
     // State 
     fn owner(self: @TContractState) -> ContractAddress;
-    fn max_voting_duration(self: @TContractState) -> u64;
-    fn min_voting_duration(self: @TContractState) -> u64;
+    fn max_voting_duration(self: @TContractState) -> u32;
+    fn min_voting_duration(self: @TContractState) -> u32;
     fn next_proposal_id(self: @TContractState) -> u256;
-    fn voting_delay(self: @TContractState) -> u64;
+    fn voting_delay(self: @TContractState) -> u32;
     fn authenticators(self: @TContractState, account: ContractAddress) -> bool;
     fn voting_strategies(self: @TContractState, index: u8) -> Strategy;
     fn active_voting_strategies(self: @TContractState) -> u256;
@@ -61,7 +62,7 @@ mod Space {
     use clone::Clone;
     use option::OptionTrait;
     use hash::LegacyHash;
-    use traits::Into;
+    use traits::{Into, TryInto};
 
     use sx::interfaces::{
         IProposalValidationStrategyDispatcher, IProposalValidationStrategyDispatcherTrait,
@@ -70,7 +71,7 @@ mod Space {
     };
     use sx::types::{
         UserAddress, Choice, FinalizationStatus, Strategy, IndexedStrategy, Proposal,
-        IndexedStrategyTrait, IndexedStrategyImpl, UpdateSettingsCalldata, NoUpdateU64,
+        IndexedStrategyTrait, IndexedStrategyImpl, UpdateSettingsCalldata, NoUpdateU32,
         NoUpdateStrategy, NoUpdateArray
     };
     use sx::utils::bits::BitSetter;
@@ -78,10 +79,10 @@ mod Space {
 
     #[storage]
     struct Storage {
-        _max_voting_duration: u64,
-        _min_voting_duration: u64,
+        _max_voting_duration: u32,
+        _min_voting_duration: u32,
         _next_proposal_id: u256,
-        _voting_delay: u64,
+        _voting_delay: u32,
         _active_voting_strategies: u256,
         _voting_strategies: LegacyMap::<u8, Strategy>,
         _next_voting_strategy_index: u8,
@@ -96,9 +97,9 @@ mod Space {
     fn SpaceCreated(
         _space: ContractAddress,
         _owner: ContractAddress,
-        _voting_delay: u64,
-        _min_voting_duration: u64,
-        _max_voting_duration: u64,
+        _voting_delay: u32,
+        _min_voting_duration: u32,
+        _max_voting_duration: u32,
         _proposal_validation_strategy: @Strategy,
         _voting_strategies: @Array<Strategy>,
         _authenticators: @Array<ContractAddress>
@@ -143,10 +144,10 @@ mod Space {
     fn DaoURIUpdated(_new_dao_uri: @Array<felt252>) {}
 
     #[event]
-    fn MaxVotingDurationUpdated(_new_max_voting_duration: u64) {}
+    fn MaxVotingDurationUpdated(_new_max_voting_duration: u32) {}
 
     #[event]
-    fn MinVotingDurationUpdated(_new_min_voting_duration: u64) {}
+    fn MinVotingDurationUpdated(_new_min_voting_duration: u32) {}
 
     #[event]
     fn ProposalValidationStrategyUpdated(
@@ -155,7 +156,7 @@ mod Space {
     ) {}
 
     #[event]
-    fn VotingDelayUpdated(_new_voting_delay: u64) {}
+    fn VotingDelayUpdated(_new_voting_delay: u32) {}
 
     #[event]
     fn Upgraded(class_hash: ClassHash) {}
@@ -181,7 +182,7 @@ mod Space {
                 );
             assert(is_valid, 'Proposal is not valid');
 
-            let snapshot_block_number = info::get_block_number();
+            let snapshot_block_number = info::get_block_number().try_into().unwrap();
             let start_block_number = snapshot_block_number + self._voting_delay.read();
             let min_end_block_number = start_block_number + self._min_voting_duration.read();
             let max_end_block_number = start_block_number + self._max_voting_duration.read();
@@ -224,7 +225,7 @@ mod Space {
             let proposal = self._proposals.read(proposal_id);
             assert_proposal_exists(@proposal);
 
-            let block_number = info::get_block_number();
+            let block_number = info::get_block_number().try_into().unwrap();
 
             assert(block_number < proposal.max_end_block_number, 'Voting period has ended');
             assert(block_number >= proposal.start_block_number, 'Voting period has not started');
@@ -288,7 +289,10 @@ mod Space {
             let mut proposal = self._proposals.read(proposal_id);
             assert_proposal_exists(@proposal);
             assert(proposal.author == author, 'Only Author');
-            assert(info::get_block_number() < proposal.start_block_number, 'Voting period started');
+            assert(
+                info::get_block_number().try_into().unwrap() < proposal.start_block_number,
+                'Voting period started'
+            );
 
             proposal.execution_strategy = execution_strategy.address;
 
@@ -332,11 +336,11 @@ mod Space {
             Ownable::owner(@state)
         }
 
-        fn max_voting_duration(self: @ContractState) -> u64 {
+        fn max_voting_duration(self: @ContractState) -> u32 {
             self._max_voting_duration.read()
         }
 
-        fn min_voting_duration(self: @ContractState) -> u64 {
+        fn min_voting_duration(self: @ContractState) -> u32 {
             self._min_voting_duration.read()
         }
 
@@ -344,7 +348,7 @@ mod Space {
             self._next_proposal_id.read()
         }
 
-        fn voting_delay(self: @ContractState) -> u64 {
+        fn voting_delay(self: @ContractState) -> u32 {
             self._voting_delay.read()
         }
 
@@ -379,17 +383,17 @@ mod Space {
             Ownable::assert_only_owner(@state);
 
             // if not NO_UPDATE
-            if NoUpdateU64::should_update(@input.max_voting_duration) {
+            if NoUpdateU32::should_update(@input.max_voting_duration) {
                 _set_max_voting_duration(ref self, input.max_voting_duration);
                 MaxVotingDurationUpdated(input.max_voting_duration);
             }
 
-            if NoUpdateU64::should_update(@input.min_voting_duration) {
+            if NoUpdateU32::should_update(@input.min_voting_duration) {
                 _set_min_voting_duration(ref self, input.min_voting_duration);
                 MinVotingDurationUpdated(input.min_voting_duration);
             }
 
-            if NoUpdateU64::should_update(@input.voting_delay) {
+            if NoUpdateU32::should_update(@input.voting_delay) {
                 _set_voting_delay(ref self, input.voting_delay);
                 VotingDelayUpdated(input.voting_delay);
             }
@@ -460,9 +464,9 @@ mod Space {
     fn constructor(
         ref self: ContractState,
         _owner: ContractAddress,
-        _max_voting_duration: u64,
-        _min_voting_duration: u64,
-        _voting_delay: u64,
+        _max_voting_duration: u32,
+        _min_voting_duration: u32,
+        _voting_delay: u32,
         _proposal_validation_strategy: Strategy,
         _voting_strategies: Array<Strategy>,
         _authenticators: Array<ContractAddress>,
@@ -506,7 +510,7 @@ mod Space {
     fn _get_cumulative_power(
         self: @ContractState,
         voter: UserAddress,
-        block_number: u64,
+        block_number: u32,
         user_strategies: Array<IndexedStrategy>,
         allowed_strategies: u256
     ) -> u256 {
@@ -531,15 +535,15 @@ mod Space {
         total_voting_power
     }
 
-    fn _set_max_voting_duration(ref self: ContractState, _max_voting_duration: u64) {
+    fn _set_max_voting_duration(ref self: ContractState, _max_voting_duration: u32) {
         self._max_voting_duration.write(_max_voting_duration);
     }
 
-    fn _set_min_voting_duration(ref self: ContractState, _min_voting_duration: u64) {
+    fn _set_min_voting_duration(ref self: ContractState, _min_voting_duration: u32) {
         self._min_voting_duration.write(_min_voting_duration);
     }
 
-    fn _set_voting_delay(ref self: ContractState, _voting_delay: u64) {
+    fn _set_voting_delay(ref self: ContractState, _voting_delay: u32) {
         self._voting_delay.write(_voting_delay);
     }
 

--- a/starknet/src/space/space.cairo
+++ b/starknet/src/space/space.cairo
@@ -290,7 +290,7 @@ mod Space {
             assert_proposal_exists(@proposal);
             assert(proposal.author == author, 'Only Author');
             assert(
-                info::get_block_number().try_into().unwrap() < proposal.start_block_number,
+                info::get_block_number() < proposal.start_block_number.into(),
                 'Voting period started'
             );
 

--- a/starknet/src/space/space.cairo
+++ b/starknet/src/space/space.cairo
@@ -182,8 +182,9 @@ mod Space {
                 );
             assert(is_valid, 'Proposal is not valid');
 
-            let snapshot_block_number = info::get_block_number().try_into().unwrap();
-            let start_block_number = snapshot_block_number + self._voting_delay.read();
+            // The snapshot block number is the start of the voting period
+            let start_block_number = info::get_block_number().try_into().unwrap()
+                + self._voting_delay.read();
             let min_end_block_number = start_block_number + self._min_voting_duration.read();
             let max_end_block_number = start_block_number + self._max_voting_duration.read();
 
@@ -194,7 +195,6 @@ mod Space {
             );
 
             let proposal = Proposal {
-                snapshot_block_number: snapshot_block_number,
                 start_block_number: start_block_number,
                 min_end_block_number: min_end_block_number,
                 max_end_block_number: max_end_block_number,
@@ -240,7 +240,7 @@ mod Space {
             let voting_power = _get_cumulative_power(
                 @self,
                 voter,
-                proposal.snapshot_block_number,
+                proposal.start_block_number,
                 user_voting_strategies,
                 proposal.active_voting_strategies
             );

--- a/starknet/src/tests/test_space.cairo
+++ b/starknet/src/tests/test_space.cairo
@@ -150,7 +150,6 @@ mod tests {
         let proposal = space.proposals(u256_from_felt252(1));
         let block_number = info::get_block_number().try_into().unwrap();
         let expected_proposal = Proposal {
-            snapshot_block_number: block_number,
             start_block_number: block_number + 1_u32,
             min_end_block_number: block_number + 2_u32,
             max_end_block_number: block_number + 3_u32,

--- a/starknet/src/tests/test_space.cairo
+++ b/starknet/src/tests/test_space.cairo
@@ -39,9 +39,9 @@ mod tests {
         testing::set_contract_address(deployer);
         // Space Settings
         let owner = contract_address_const::<0x123456789>();
-        let max_voting_duration = 2_u64;
-        let min_voting_duration = 1_u64;
-        let voting_delay = 1_u64;
+        let max_voting_duration = 2_u32;
+        let min_voting_duration = 1_u32;
+        let voting_delay = 1_u32;
 
         // Deploy Vanilla Authenticator 
         let (vanilla_authenticator_address, _) = deploy_syscall(
@@ -148,11 +148,12 @@ mod tests {
         );
 
         let proposal = space.proposals(u256_from_felt252(1));
+        let block_number = info::get_block_number().try_into().unwrap();
         let expected_proposal = Proposal {
-            snapshot_block_number: info::get_block_number(),
-            start_block_number: info::get_block_number() + 1_u64,
-            min_end_block_number: info::get_block_number() + 2_u64,
-            max_end_block_number: info::get_block_number() + 3_u64,
+            snapshot_block_number: block_number,
+            start_block_number: block_number + 1_u32,
+            min_end_block_number: block_number + 2_u32,
+            max_end_block_number: block_number + 3_u32,
             execution_payload_hash: poseidon::poseidon_hash_span(
                 vanilla_execution_strategy.clone().params.span()
             ),

--- a/starknet/src/tests/test_space.cairo
+++ b/starknet/src/tests/test_space.cairo
@@ -149,10 +149,10 @@ mod tests {
 
         let proposal = space.proposals(u256_from_felt252(1));
         let expected_proposal = Proposal {
-            snapshot_timestamp: info::get_block_timestamp(),
-            start_timestamp: info::get_block_timestamp() + 1_u64,
-            min_end_timestamp: info::get_block_timestamp() + 2_u64,
-            max_end_timestamp: info::get_block_timestamp() + 3_u64,
+            snapshot_block_number: info::get_block_number(),
+            start_block_number: info::get_block_number() + 1_u64,
+            min_end_block_number: info::get_block_number() + 2_u64,
+            max_end_block_number: info::get_block_number() + 3_u64,
             execution_payload_hash: poseidon::poseidon_hash_span(
                 vanilla_execution_strategy.clone().params.span()
             ),
@@ -179,8 +179,8 @@ mod tests {
         authenticator
             .authenticate(space.contract_address, UPDATE_PROPOSAL_SELECTOR, update_calldata);
 
-        // Increasing block timestamp by 1 to pass voting delay
-        testing::set_block_timestamp(1_u64);
+        // Increasing block block_number by 1 to pass voting delay
+        testing::set_block_number(1_u64);
 
         let mut vote_calldata = array::ArrayTrait::<felt252>::new();
         let voter = UserAddress::Starknet(contract_address_const::<0x8765>());
@@ -197,7 +197,7 @@ mod tests {
         // Vote on Proposal
         authenticator.authenticate(space.contract_address, VOTE_SELECTOR, vote_calldata);
 
-        testing::set_block_timestamp(2_u64);
+        testing::set_block_number(2_u64);
 
         // Execute Proposal
         space.execute(u256_from_felt252(1), vanilla_execution_strategy.params);
@@ -297,8 +297,8 @@ mod tests {
         authenticator.authenticate(space.contract_address, PROPOSE_SELECTOR, propose_calldata);
         let proposal_id = u256_from_felt252(1);
 
-        // Increasing block timestamp by 1 to pass voting delay
-        testing::set_block_timestamp(1_u64);
+        // Increasing block block_number by 1 to pass voting delay
+        testing::set_block_number(1_u64);
         let proposal = space.proposals(proposal_id);
         assert(proposal.finalization_status == FinalizationStatus::Pending(()), 'pending');
 

--- a/starknet/src/types.cairo
+++ b/starknet/src/types.cairo
@@ -23,5 +23,4 @@ mod update_settings_calldata;
 use update_settings_calldata::{
     UpdateSettingsCalldata, UpdateSettingsCalldataImpl, UpdateSettingsCalldataTrait, NoUpdateArray,
     NoUpdateContractAddress, NoUpdateFelt252, NoUpdateStrategy, NoUpdateTrait, NoUpdateU32,
-    NoUpdateU64
 };

--- a/starknet/src/types/proposal.cairo
+++ b/starknet/src/types/proposal.cairo
@@ -3,13 +3,12 @@ use serde::Serde;
 use starknet::ContractAddress;
 use sx::types::{FinalizationStatus, UserAddress};
 
-/// NOTE: Using u64 for block numbers instead of u32 which we use in sx-evm. can change if needed.
 #[derive(Clone, Drop, Serde, PartialEq, starknet::Store)]
 struct Proposal {
-    snapshot_block_number: u64,
-    start_block_number: u64,
-    min_end_block_number: u64,
-    max_end_block_number: u64,
+    snapshot_block_number: u32,
+    start_block_number: u32,
+    min_end_block_number: u32,
+    max_end_block_number: u32,
     execution_payload_hash: felt252,
     execution_strategy: ContractAddress,
     author: UserAddress,

--- a/starknet/src/types/proposal.cairo
+++ b/starknet/src/types/proposal.cairo
@@ -3,13 +3,13 @@ use serde::Serde;
 use starknet::ContractAddress;
 use sx::types::{FinalizationStatus, UserAddress};
 
-/// NOTE: Using u64 for timestamps instead of u32 which we use in sx-evm. can change if needed.
+/// NOTE: Using u64 for block numbers instead of u32 which we use in sx-evm. can change if needed.
 #[derive(Clone, Drop, Serde, PartialEq, starknet::Store)]
 struct Proposal {
-    snapshot_timestamp: u64,
-    start_timestamp: u64,
-    min_end_timestamp: u64,
-    max_end_timestamp: u64,
+    snapshot_block_number: u64,
+    start_block_number: u64,
+    min_end_block_number: u64,
+    max_end_block_number: u64,
     execution_payload_hash: felt252,
     execution_strategy: ContractAddress,
     author: UserAddress,

--- a/starknet/src/types/proposal.cairo
+++ b/starknet/src/types/proposal.cairo
@@ -5,7 +5,6 @@ use sx::types::{FinalizationStatus, UserAddress};
 
 #[derive(Clone, Drop, Serde, PartialEq, starknet::Store)]
 struct Proposal {
-    snapshot_block_number: u32,
     start_block_number: u32,
     min_end_block_number: u32,
     max_end_block_number: u32,

--- a/starknet/src/types/update_settings_calldata.cairo
+++ b/starknet/src/types/update_settings_calldata.cairo
@@ -3,12 +3,11 @@ use clone::Clone;
 use starknet::{ContractAddress, contract_address_const};
 use sx::types::Strategy;
 
-// TODO: move to u32
 #[derive(Clone, Drop, Serde)]
 struct UpdateSettingsCalldata {
-    min_voting_duration: u64,
-    max_voting_duration: u64,
-    voting_delay: u64,
+    min_voting_duration: u32,
+    max_voting_duration: u32,
+    voting_delay: u32,
     metadata_URI: Array<felt252>,
     dao_URI: Array<felt252>,
     proposal_validation_strategy: Strategy,
@@ -41,16 +40,6 @@ impl NoUpdateU32 of NoUpdateTrait<u32> {
 
     fn should_update(self: @u32) -> bool {
         *self != 0xf2cda9b1
-    }
-}
-
-impl NoUpdateU64 of NoUpdateTrait<u64> {
-    fn no_update() -> u64 {
-        0xf2cda9b13ed04e58
-    }
-
-    fn should_update(self: @u64) -> bool {
-        *self != 0xf2cda9b13ed04e58
     }
 }
 
@@ -101,13 +90,12 @@ impl NoUpdateArray<T> of NoUpdateTrait<Array<T>> {
     }
 }
 
-
 impl UpdateSettingsCalldataImpl of UpdateSettingsCalldataTrait {
     fn default() -> UpdateSettingsCalldata {
         UpdateSettingsCalldata {
-            min_voting_duration: NoUpdateU64::no_update(),
-            max_voting_duration: NoUpdateU64::no_update(),
-            voting_delay: NoUpdateU64::no_update(),
+            min_voting_duration: NoUpdateU32::no_update(),
+            max_voting_duration: NoUpdateU32::no_update(),
+            voting_delay: NoUpdateU32::no_update(),
             metadata_URI: NoUpdateArray::no_update(), // TODO: string
             dao_URI: NoUpdateArray::no_update(), // TODO: string
             proposal_validation_strategy: NoUpdateStrategy::no_update(),

--- a/starknet/src/utils/single_slot_proof.cairo
+++ b/starknet/src/utils/single_slot_proof.cairo
@@ -65,7 +65,7 @@ mod SingleSlotProof {
     #[internal]
     fn get_storage_slot(
         self: @ContractState,
-        block_number: u64,
+        block_number: u32,
         contract_address: felt252,
         slot_index: u256,
         mapping_key: u256,

--- a/starknet/src/voting_strategies/eth_balance_of.cairo
+++ b/starknet/src/voting_strategies/eth_balance_of.cairo
@@ -13,7 +13,7 @@ mod EthBalanceOfVotingStrategy {
     impl EthBalanceOfVotingStrategy of IVotingStrategy<ContractState> {
         fn get_voting_power(
             self: @ContractState,
-            timestamp: u32,
+            block_number: u32,
             voter: UserAddress,
             params: Array<felt252>,
             user_params: Array<felt252>,

--- a/starknet/src/voting_strategies/eth_balance_of.cairo
+++ b/starknet/src/voting_strategies/eth_balance_of.cairo
@@ -13,7 +13,7 @@ mod EthBalanceOfVotingStrategy {
     impl EthBalanceOfVotingStrategy of IVotingStrategy<ContractState> {
         fn get_voting_power(
             self: @ContractState,
-            timestamp: u64,
+            timestamp: u32,
             voter: UserAddress,
             params: Array<felt252>,
             user_params: Array<felt252>,

--- a/starknet/src/voting_strategies/eth_balance_of.cairo
+++ b/starknet/src/voting_strategies/eth_balance_of.cairo
@@ -22,10 +22,6 @@ mod EthBalanceOfVotingStrategy {
             // Will revert if the address is not an Ethereum address
             let voter = voter.to_ethereum_address();
 
-            // Resolve timestamp to block number
-            //TODO: dummy var for now. Remove when timestamps are replaced with block numbers
-            let block_number = 1;
-
             // Decode params 
             let contract_address = (*params[0]).into();
             let slot_index = (*params[1]).into();

--- a/starknet/src/voting_strategies/vanilla.cairo
+++ b/starknet/src/voting_strategies/vanilla.cairo
@@ -11,7 +11,7 @@ mod VanillaVotingStrategy {
     impl VanillaVotingStrategy of IVotingStrategy<ContractState> {
         fn get_voting_power(
             self: @ContractState,
-            timestamp: u64,
+            timestamp: u32,
             voter: UserAddress,
             params: Array<felt252>,
             user_params: Array<felt252>,

--- a/starknet/src/voting_strategies/vanilla.cairo
+++ b/starknet/src/voting_strategies/vanilla.cairo
@@ -11,7 +11,7 @@ mod VanillaVotingStrategy {
     impl VanillaVotingStrategy of IVotingStrategy<ContractState> {
         fn get_voting_power(
             self: @ContractState,
-            timestamp: u32,
+            block_number: u32,
             voter: UserAddress,
             params: Array<felt252>,
             user_params: Array<felt252>,


### PR DESCRIPTION
To match the sx-evm architecture post audit, we make the following changes to time tracking: 
 - migrates u64 timestamps to u32 block numbers for `voting_delay`, `min_voting_duration` and `max_voting_duration`. 
- Moves the snapshot timestamp to be the start of the voting period. 