### PR TITLE
chore: migrate to array macro

### DIFF
--- a/starknet/src/authenticators/eth_tx.cairo
+++ b/starknet/src/authenticators/eth_tx.cairo
@@ -61,7 +61,7 @@ mod EthTxAuthenticator {
             user_proposal_validation_params: Array<felt252>,
             metadata_URI: Array<felt252>
         ) {
-            let mut payload = ArrayTrait::<felt252>::new();
+            let mut payload = array![];
             target.serialize(ref payload);
             PROPOSE_SELECTOR.serialize(ref payload);
             author.serialize(ref payload);
@@ -92,7 +92,7 @@ mod EthTxAuthenticator {
             user_voting_strategies: Array<IndexedStrategy>,
             metadata_URI: Array<felt252>
         ) {
-            let mut payload = ArrayTrait::<felt252>::new();
+            let mut payload = array![];
             target.serialize(ref payload);
             VOTE_SELECTOR.serialize(ref payload);
             voter.serialize(ref payload);
@@ -124,7 +124,7 @@ mod EthTxAuthenticator {
             execution_strategy: Strategy,
             metadata_URI: Array<felt252>
         ) {
-            let mut payload = ArrayTrait::<felt252>::new();
+            let mut payload = array![];
             target.serialize(ref payload);
             UPDATE_PROPOSAL_SELECTOR.serialize(ref payload);
             author.serialize(ref payload);

--- a/starknet/src/execution_strategies/eth_relayer.cairo
+++ b/starknet/src/execution_strategies/eth_relayer.cairo
@@ -22,7 +22,7 @@ mod EthRelayerExecutionStrategy {
             // keccak hash of the proposal execution payload
             let execution_hash = u256 { low: payload[2], high: payload[1] };
 
-            let mut message_payload = ArrayTrait::<felt252>::new();
+            let mut message_payload = array![];
             space.serialize(mut message_payload);
             proposal.serialize(mut message_payload);
             votes_for.serialize(mut message_payload);

--- a/starknet/src/tests/setup/setup.cairo
+++ b/starknet/src/tests/setup/setup.cairo
@@ -44,10 +44,7 @@ mod setup {
 
         // Deploy Vanilla Authenticator 
         let (vanilla_authenticator_address, _) = deploy_syscall(
-            VanillaAuthenticator::TEST_CLASS_HASH.try_into().unwrap(),
-            0,
-            array::ArrayTrait::<felt252>::new().span(),
-            false
+            VanillaAuthenticator::TEST_CLASS_HASH.try_into().unwrap(), 0, array![].span(), false
         )
             .unwrap();
         let mut authenticators = ArrayTrait::<ContractAddress>::new();
@@ -57,7 +54,7 @@ mod setup {
         let (vanilla_proposal_validation_address, _) = deploy_syscall(
             VanillaProposalValidationStrategy::TEST_CLASS_HASH.try_into().unwrap(),
             0,
-            array::ArrayTrait::<felt252>::new().span(),
+            array![].span(),
             false
         )
             .unwrap();
@@ -67,22 +64,15 @@ mod setup {
 
         // Deploy Vanilla Voting Strategy 
         let (vanilla_voting_strategy_address, _) = deploy_syscall(
-            VanillaVotingStrategy::TEST_CLASS_HASH.try_into().unwrap(),
-            0,
-            array::ArrayTrait::<felt252>::new().span(),
-            false
+            VanillaVotingStrategy::TEST_CLASS_HASH.try_into().unwrap(), 0, array![].span(), false
         )
             .unwrap();
         let mut voting_strategies = ArrayTrait::<Strategy>::new();
         voting_strategies
-            .append(
-                Strategy {
-                    address: vanilla_voting_strategy_address, params: ArrayTrait::<felt252>::new()
-                }
-            );
+            .append(Strategy { address: vanilla_voting_strategy_address, params: array![] });
 
         // Deploy Vanilla Execution Strategy 
-        let mut constructor_calldata = ArrayTrait::<felt252>::new();
+        let mut constructor_calldata = array![];
         quorum.serialize(ref constructor_calldata);
         let (vanilla_execution_strategy_address, _) = deploy_syscall(
             VanillaExecutionStrategy::TEST_CLASS_HASH.try_into().unwrap(),
@@ -116,7 +106,7 @@ mod setup {
         authenticators: @Array<ContractAddress>
     ) -> Array<felt252> {
         // Using empty arrays for all the metadata fields
-        let mut constructor_calldata = array::ArrayTrait::<felt252>::new();
+        let mut constructor_calldata = array![];
         constructor_calldata.append((*owner).into());
         constructor_calldata.append((*max_voting_duration).into());
         constructor_calldata.append((*min_voting_duration).into());
@@ -137,10 +127,7 @@ mod setup {
         let contract_address_salt = 0;
 
         let (factory_address, _) = deploy_syscall(
-            Factory::TEST_CLASS_HASH.try_into().unwrap(),
-            0,
-            ArrayTrait::<felt252>::new().span(),
-            false
+            Factory::TEST_CLASS_HASH.try_into().unwrap(), 0, array![].span(), false
         )
             .unwrap();
 

--- a/starknet/src/tests/test_factory.cairo
+++ b/starknet/src/tests/test_factory.cairo
@@ -26,7 +26,7 @@ mod tests {
     #[test]
     #[available_gas(10000000000)]
     fn test_deploy_reuse_salt() {
-        let mut constructor_calldata = ArrayTrait::<felt252>::new();
+        let mut constructor_calldata = array![];
 
         let (factory_address, _) = deploy_syscall(
             Factory::TEST_CLASS_HASH.try_into().unwrap(), 0, constructor_calldata.span(), false

--- a/starknet/src/tests/test_merkle_whitelist.cairo
+++ b/starknet/src/tests/test_merkle_whitelist.cairo
@@ -13,7 +13,7 @@ mod merkle_utils {
     impl SpanIntoArray<T, impl TClone: Clone<T>, impl TDrop: Drop<T>> of Into<Span<T>, Array<T>> {
         fn into(self: Span<T>) -> Array<T> {
             let mut self = self;
-            let mut output = ArrayTrait::<T>::new();
+            let mut output = array![];
             loop {
                 match self.pop_front() {
                     Option::Some(val) => output.append(val.clone()),
@@ -28,7 +28,7 @@ mod merkle_utils {
 
     // Generates the proof for the given `index` in the `merkle_data`.
     fn generate_proof(mut merkle_data: Span<felt252>, mut index: usize) -> Array<felt252> {
-        let mut proof = ArrayTrait::new();
+        let mut proof = array![];
 
         loop {
             if merkle_data.len() == 1 {
@@ -82,7 +82,7 @@ mod merkle_utils {
     }
 
     fn get_next_level(mut merkle_data: Span<felt252>) -> Array<felt252> {
-        let mut next_level = ArrayTrait::<felt252>::new();
+        let mut next_level = array![];
         loop {
             match merkle_data.pop_front() {
                 Option::Some(a) => {
@@ -114,7 +114,7 @@ mod merkle_utils {
     // The `merkle_data` corresponds to the hashes leaves of the members.
     fn generate_merkle_data(members: Span<Leaf>) -> Array<felt252> {
         let mut members_ = members;
-        let mut output = ArrayTrait::<felt252>::new();
+        let mut output = array![];
         loop {
             match members_.pop_front() {
                 Option::Some(leaf) => {
@@ -132,7 +132,7 @@ mod merkle_utils {
     // address 1, 2, 3, ...
     // Even members will be Ethereum addresses and odd members will be Starknet addresses.
     fn generate_n_members(n: usize) -> Array<Leaf> {
-        let mut members = ArrayTrait::<Leaf>::new();
+        let mut members = array![];
         let mut i = 1_usize;
         loop {
             if i >= n + 1 {
@@ -251,7 +251,7 @@ mod assert_valid_proof {
         let leaf = Leaf {
             address: UserAddress::Starknet(contract_address_const::<0>()), voting_power: 0
         };
-        let proof = ArrayTrait::new();
+        let proof = array![];
         assert_valid_proof(root, leaf, proof.span());
     }
 
@@ -259,37 +259,19 @@ mod assert_valid_proof {
     #[available_gas(10000000)]
     #[should_panic(expected: ('Merkle: Invalid proof', ))]
     fn invalid_extra_node() {
-        let mut members = ArrayTrait::new();
-        members
-            .append(
-                Leaf {
-                    address: UserAddress::Starknet(contract_address_const::<5>()), voting_power: 5
-                }
-            );
-        members
-            .append(
-                Leaf {
-                    address: UserAddress::Starknet(contract_address_const::<4>()), voting_power: 4
-                }
-            );
-        members
-            .append(
-                Leaf {
-                    address: UserAddress::Starknet(contract_address_const::<3>()), voting_power: 3
-                }
-            );
-        members
-            .append(
-                Leaf {
-                    address: UserAddress::Starknet(contract_address_const::<2>()), voting_power: 2
-                }
-            );
-        members
-            .append(
-                Leaf {
-                    address: UserAddress::Starknet(contract_address_const::<1>()), voting_power: 1
-                }
-            );
+        let mut members = array![
+            Leaf {
+                address: UserAddress::Starknet(contract_address_const::<5>()), voting_power: 5
+                }, Leaf {
+                address: UserAddress::Starknet(contract_address_const::<4>()), voting_power: 4
+                }, Leaf {
+                address: UserAddress::Starknet(contract_address_const::<3>()), voting_power: 3
+                }, Leaf {
+                address: UserAddress::Starknet(contract_address_const::<2>()), voting_power: 2
+                }, Leaf {
+                address: UserAddress::Starknet(contract_address_const::<1>()), voting_power: 1
+            },
+        ];
         let merkle_data = generate_merkle_data(members.span());
 
         let root = generate_merkle_root(merkle_data.span());
@@ -304,37 +286,19 @@ mod assert_valid_proof {
     #[available_gas(10000000)]
     #[should_panic(expected: ('Merkle: Invalid proof', ))]
     fn invalid_proof() {
-        let mut members = ArrayTrait::new();
-        members
-            .append(
-                Leaf {
-                    address: UserAddress::Starknet(contract_address_const::<5>()), voting_power: 5
-                }
-            );
-        members
-            .append(
-                Leaf {
-                    address: UserAddress::Starknet(contract_address_const::<4>()), voting_power: 4
-                }
-            );
-        members
-            .append(
-                Leaf {
-                    address: UserAddress::Starknet(contract_address_const::<3>()), voting_power: 3
-                }
-            );
-        members
-            .append(
-                Leaf {
-                    address: UserAddress::Starknet(contract_address_const::<2>()), voting_power: 2
-                }
-            );
-        members
-            .append(
-                Leaf {
-                    address: UserAddress::Starknet(contract_address_const::<1>()), voting_power: 1
-                }
-            );
+        let mut members = array![
+            Leaf {
+                address: UserAddress::Starknet(contract_address_const::<5>()), voting_power: 5
+                }, Leaf {
+                address: UserAddress::Starknet(contract_address_const::<4>()), voting_power: 4
+                }, Leaf {
+                address: UserAddress::Starknet(contract_address_const::<3>()), voting_power: 3
+                }, Leaf {
+                address: UserAddress::Starknet(contract_address_const::<2>()), voting_power: 2
+                }, Leaf {
+                address: UserAddress::Starknet(contract_address_const::<1>()), voting_power: 1
+            },
+        ];
         let merkle_data = generate_merkle_data(members.span());
 
         let root = generate_merkle_root(merkle_data.span());
@@ -373,7 +337,7 @@ mod merkle_whitelist_voting_power {
         let (contract, _) = deploy_syscall(
             MerkleWhitelistVotingStrategy::TEST_CLASS_HASH.try_into().unwrap(),
             0,
-            array::ArrayTrait::<felt252>::new().span(),
+            array![].span(),
             false,
         )
             .unwrap();
@@ -387,10 +351,10 @@ mod merkle_whitelist_voting_power {
         let root = generate_merkle_root(merkle_data.span());
         let proof = generate_proof(merkle_data.span(), index);
 
-        let mut params = ArrayTrait::<felt252>::new();
+        let mut params = array![];
         root.serialize(ref params);
 
-        let mut user_params = ArrayTrait::<felt252>::new();
+        let mut user_params = array![];
         leaf.serialize(ref user_params);
         proof.serialize(ref user_params);
 
@@ -406,7 +370,7 @@ mod merkle_whitelist_voting_power {
         let (contract, _) = deploy_syscall(
             MerkleWhitelistVotingStrategy::TEST_CLASS_HASH.try_into().unwrap(),
             0,
-            array::ArrayTrait::<felt252>::new().span(),
+            array![].span(),
             false,
         )
             .unwrap();
@@ -420,10 +384,10 @@ mod merkle_whitelist_voting_power {
         let root = generate_merkle_root(merkle_data.span());
         let proof = generate_proof(merkle_data.span(), index);
 
-        let mut params = ArrayTrait::<felt252>::new();
+        let mut params = array![];
         root.serialize(ref params);
 
-        let mut user_params = ArrayTrait::<felt252>::new();
+        let mut user_params = array![];
         let fake_leaf = Leaf {
             address: leaf.address, voting_power: leaf.voting_power + 1, 
         }; // lying about voting power here
@@ -442,7 +406,7 @@ mod merkle_whitelist_voting_power {
         let (contract, _) = deploy_syscall(
             MerkleWhitelistVotingStrategy::TEST_CLASS_HASH.try_into().unwrap(),
             0,
-            array::ArrayTrait::<felt252>::new().span(),
+            array![].span(),
             false,
         )
             .unwrap();
@@ -456,10 +420,10 @@ mod merkle_whitelist_voting_power {
         let root = generate_merkle_root(merkle_data.span());
         let proof = generate_proof(merkle_data.span(), index);
 
-        let mut params = ArrayTrait::<felt252>::new();
+        let mut params = array![];
         root.serialize(ref params);
 
-        let mut user_params = ArrayTrait::<felt252>::new();
+        let mut user_params = array![];
         let fake_leaf = Leaf {
             address: UserAddress::Starknet(contract_address_const::<0x1337>()),
             voting_power: leaf.voting_power,

--- a/starknet/src/tests/test_space.cairo
+++ b/starknet/src/tests/test_space.cairo
@@ -45,20 +45,16 @@ mod tests {
 
         // Deploy Vanilla Authenticator 
         let (vanilla_authenticator_address, _) = deploy_syscall(
-            VanillaAuthenticator::TEST_CLASS_HASH.try_into().unwrap(),
-            0,
-            array::ArrayTrait::<felt252>::new().span(),
-            false
+            VanillaAuthenticator::TEST_CLASS_HASH.try_into().unwrap(), 0, array![].span(), false
         )
             .unwrap();
-        let mut authenticators = ArrayTrait::<ContractAddress>::new();
-        authenticators.append(vanilla_authenticator_address);
+        let mut authenticators = array![vanilla_authenticator_address];
 
         // Deploy Vanilla Proposal Validation Strategy
         let (vanilla_proposal_validation_address, _) = deploy_syscall(
             VanillaProposalValidationStrategy::TEST_CLASS_HASH.try_into().unwrap(),
             0,
-            array::ArrayTrait::<felt252>::new().span(),
+            array![].span(),
             false
         )
             .unwrap();
@@ -68,26 +64,20 @@ mod tests {
 
         // Deploy Vanilla Voting Strategy 
         let (vanilla_voting_strategy_address, _) = deploy_syscall(
-            VanillaVotingStrategy::TEST_CLASS_HASH.try_into().unwrap(),
-            0,
-            array::ArrayTrait::<felt252>::new().span(),
-            false
+            VanillaVotingStrategy::TEST_CLASS_HASH.try_into().unwrap(), 0, array![].span(), false
         )
             .unwrap();
-        let mut voting_strategies = ArrayTrait::<Strategy>::new();
-        voting_strategies
-            .append(
-                Strategy {
-                    address: vanilla_voting_strategy_address, params: ArrayTrait::<felt252>::new()
-                }
-            );
+        let mut voting_strategies = array![
+            Strategy { address: vanilla_voting_strategy_address, params: array![] }
+        ];
 
         // Deploy Space 
-        let mut constructor_calldata = array::ArrayTrait::<felt252>::new();
-        constructor_calldata.append(owner.into());
-        constructor_calldata.append(max_voting_duration.into());
-        constructor_calldata.append(min_voting_duration.into());
-        constructor_calldata.append(voting_delay.into());
+        let mut constructor_calldata = array![
+            owner.into(),
+            max_voting_duration.into(),
+            min_voting_duration.into(),
+            voting_delay.into()
+        ];
         vanilla_proposal_validation_strategy.serialize(ref constructor_calldata);
         ArrayTrait::<felt252>::new().serialize(ref constructor_calldata);
         voting_strategies.serialize(ref constructor_calldata);
@@ -124,7 +114,7 @@ mod tests {
         };
 
         let quorum = u256_from_felt252(1);
-        let mut constructor_calldata = ArrayTrait::<felt252>::new();
+        let mut constructor_calldata = array![];
         quorum.serialize(ref constructor_calldata);
 
         let (vanilla_execution_strategy_address, _) = deploy_syscall(
@@ -138,7 +128,7 @@ mod tests {
             vanilla_execution_strategy_address
         );
         let author = UserAddress::Starknet(contract_address_const::<0x5678>());
-        let mut propose_calldata = array::ArrayTrait::<felt252>::new();
+        let mut propose_calldata = array![];
         author.serialize(ref propose_calldata);
         vanilla_execution_strategy.serialize(ref propose_calldata);
         ArrayTrait::<felt252>::new().serialize(ref propose_calldata);
@@ -169,13 +159,12 @@ mod tests {
         assert(proposal == expected_proposal, 'proposal state');
 
         // Update Proposal
-        let mut update_calldata = array::ArrayTrait::<felt252>::new();
+        let mut update_calldata = array![];
         author.serialize(ref update_calldata);
         let proposal_id = u256_from_felt252(1);
         proposal_id.serialize(ref update_calldata);
         // Keeping the same execution strategy contract but changing the payload
-        let mut new_payload = ArrayTrait::<felt252>::new();
-        new_payload.append(1);
+        let mut new_payload = array![1];
         let execution_strategy = Strategy {
             address: vanilla_execution_strategy.address, params: new_payload
         };
@@ -188,16 +177,14 @@ mod tests {
         // Increasing block timestamp by 1 to pass voting delay
         testing::set_block_timestamp(1_u64);
 
-        let mut vote_calldata = array::ArrayTrait::<felt252>::new();
+        let mut vote_calldata = array![];
         let voter = UserAddress::Starknet(contract_address_const::<0x8765>());
         voter.serialize(ref vote_calldata);
         let proposal_id = u256_from_felt252(1);
         proposal_id.serialize(ref vote_calldata);
         let choice = Choice::For(());
         choice.serialize(ref vote_calldata);
-        let mut user_voting_strategies = ArrayTrait::<IndexedStrategy>::new();
-        user_voting_strategies
-            .append(IndexedStrategy { index: 0_u8, params: ArrayTrait::<felt252>::new() });
+        let mut user_voting_strategies = array![IndexedStrategy { index: 0_u8, params: array![] }];
         user_voting_strategies.serialize(ref vote_calldata);
         ArrayTrait::<felt252>::new().serialize(ref vote_calldata);
 
@@ -221,7 +208,7 @@ mod tests {
         };
 
         let quorum = u256_from_felt252(1);
-        let mut constructor_calldata = ArrayTrait::<felt252>::new();
+        let mut constructor_calldata = array![];
         quorum.serialize(ref constructor_calldata);
 
         let (vanilla_execution_strategy_address, _) = deploy_syscall(
@@ -244,7 +231,7 @@ mod tests {
         let (strategy_address, _) = deploy_syscall(
             AlwaysFailProposalValidationStrategy::TEST_CLASS_HASH.try_into().unwrap(),
             0,
-            array::ArrayTrait::<felt252>::new().span(),
+            array![].span(),
             false
         )
             .unwrap();
@@ -257,7 +244,7 @@ mod tests {
         space.update_settings(input);
 
         let author = UserAddress::Starknet(contract_address_const::<0x5678>());
-        let mut propose_calldata = array::ArrayTrait::<felt252>::new();
+        let mut propose_calldata = array![];
         author.serialize(ref propose_calldata);
         vanilla_execution_strategy.serialize(ref propose_calldata);
         ArrayTrait::<felt252>::new().serialize(ref propose_calldata);
@@ -282,7 +269,7 @@ mod tests {
         };
 
         let quorum = u256_from_felt252(1);
-        let mut constructor_calldata = ArrayTrait::<felt252>::new();
+        let mut constructor_calldata = array![];
         quorum.serialize(ref constructor_calldata);
 
         let (vanilla_execution_strategy_address, _) = deploy_syscall(
@@ -295,7 +282,7 @@ mod tests {
         let vanilla_execution_strategy = StrategyImpl::from_address(
             vanilla_execution_strategy_address
         );
-        let mut propose_calldata = array::ArrayTrait::<felt252>::new();
+        let mut propose_calldata = array![];
         let author = UserAddress::Starknet(contract_address_const::<0x5678>());
         author.serialize(ref propose_calldata);
         vanilla_execution_strategy.serialize(ref propose_calldata);
@@ -320,15 +307,13 @@ mod tests {
         assert(proposal.finalization_status == FinalizationStatus::Cancelled(()), 'cancelled');
 
         // Try to cast vote on Cancelled Proposal
-        let mut vote_calldata = array::ArrayTrait::<felt252>::new();
+        let mut vote_calldata = array![];
         let voter = UserAddress::Starknet(contract_address_const::<0x8765>());
         voter.serialize(ref vote_calldata);
         proposal_id.serialize(ref vote_calldata);
         let choice = Choice::For(());
         choice.serialize(ref vote_calldata);
-        let mut user_voting_strategies = ArrayTrait::<IndexedStrategy>::new();
-        user_voting_strategies
-            .append(IndexedStrategy { index: 0_u8, params: ArrayTrait::<felt252>::new() });
+        let mut user_voting_strategies = array![IndexedStrategy { index: 0_u8, params: array![] }];
         user_voting_strategies.serialize(ref vote_calldata);
         ArrayTrait::<felt252>::new().serialize(ref vote_calldata);
         authenticator.authenticate(space.contract_address, VOTE_SELECTOR, vote_calldata);

--- a/starknet/src/tests/test_stark_tx_auth.cairo
+++ b/starknet/src/tests/test_stark_tx_auth.cairo
@@ -53,7 +53,7 @@ mod tests {
         let authenticator = setup_stark_tx_auth(space, config.owner);
 
         let quorum = u256_from_felt252(1);
-        let mut constructor_calldata = ArrayTrait::<felt252>::new();
+        let mut constructor_calldata = array![];
         quorum.serialize(ref constructor_calldata);
 
         let (vanilla_execution_strategy_address, _) = deploy_syscall(
@@ -72,11 +72,7 @@ mod tests {
         testing::set_contract_address(author);
         authenticator
             .authenticate_propose(
-                space.contract_address,
-                author,
-                vanilla_execution_strategy,
-                ArrayTrait::<felt252>::new(),
-                ArrayTrait::<felt252>::new()
+                space.contract_address, author, vanilla_execution_strategy, array![], array![]
             );
 
         assert(
@@ -88,8 +84,7 @@ mod tests {
 
         let proposal_id = u256_from_felt252(1);
         // Keeping the same execution strategy contract but changing the payload
-        let mut new_payload = ArrayTrait::<felt252>::new();
-        new_payload.append(1);
+        let mut new_payload = array![1];
         let new_execution_strategy = Strategy {
             address: vanilla_execution_strategy_address, params: new_payload.clone()
         };
@@ -97,11 +92,7 @@ mod tests {
         testing::set_contract_address(author);
         authenticator
             .authenticate_update_proposal(
-                space.contract_address,
-                author,
-                proposal_id,
-                new_execution_strategy,
-                ArrayTrait::<felt252>::new()
+                space.contract_address, author, proposal_id, new_execution_strategy, array![]
             );
 
         // Increasing block timestamp by 1 to pass voting delay
@@ -109,20 +100,13 @@ mod tests {
 
         let voter = contract_address_const::<0x8765>();
         let choice = Choice::For(());
-        let mut user_voting_strategies = ArrayTrait::<IndexedStrategy>::new();
-        user_voting_strategies
-            .append(IndexedStrategy { index: 0_u8, params: ArrayTrait::<felt252>::new() });
+        let mut user_voting_strategies = array![IndexedStrategy { index: 0_u8, params: array![] }];
 
         // Vote on Proposal
         testing::set_contract_address(voter);
         authenticator
             .authenticate_vote(
-                space.contract_address,
-                voter,
-                proposal_id,
-                choice,
-                user_voting_strategies,
-                ArrayTrait::<felt252>::new()
+                space.contract_address, voter, proposal_id, choice, user_voting_strategies, array![]
             );
 
         testing::set_block_timestamp(2_u64);
@@ -140,7 +124,7 @@ mod tests {
         let authenticator = setup_stark_tx_auth(space, config.owner);
 
         let quorum = u256_from_felt252(1);
-        let mut constructor_calldata = ArrayTrait::<felt252>::new();
+        let mut constructor_calldata = array![];
         quorum.serialize(ref constructor_calldata);
 
         let (vanilla_execution_strategy_address, _) = deploy_syscall(
@@ -159,11 +143,7 @@ mod tests {
         testing::set_contract_address(config.owner);
         authenticator
             .authenticate_propose(
-                space.contract_address,
-                author,
-                vanilla_execution_strategy,
-                ArrayTrait::<felt252>::new(),
-                ArrayTrait::<felt252>::new()
+                space.contract_address, author, vanilla_execution_strategy, array![], array![]
             );
     }
 
@@ -176,7 +156,7 @@ mod tests {
         let authenticator = setup_stark_tx_auth(space, config.owner);
 
         let quorum = u256_from_felt252(1);
-        let mut constructor_calldata = ArrayTrait::<felt252>::new();
+        let mut constructor_calldata = array![];
         quorum.serialize(ref constructor_calldata);
 
         let (vanilla_execution_strategy_address, _) = deploy_syscall(
@@ -195,11 +175,7 @@ mod tests {
         testing::set_contract_address(author);
         authenticator
             .authenticate_propose(
-                space.contract_address,
-                author,
-                vanilla_execution_strategy,
-                ArrayTrait::<felt252>::new(),
-                ArrayTrait::<felt252>::new()
+                space.contract_address, author, vanilla_execution_strategy, array![], array![]
             );
 
         assert(
@@ -211,8 +187,7 @@ mod tests {
 
         let proposal_id = u256_from_felt252(1);
         // Keeping the same execution strategy contract but changing the payload
-        let mut new_payload = ArrayTrait::<felt252>::new();
-        new_payload.append(1);
+        let mut new_payload = array![1];
         let new_execution_strategy = Strategy {
             address: vanilla_execution_strategy_address, params: new_payload.clone()
         };
@@ -221,11 +196,7 @@ mod tests {
         testing::set_contract_address(config.owner);
         authenticator
             .authenticate_update_proposal(
-                space.contract_address,
-                author,
-                proposal_id,
-                new_execution_strategy,
-                ArrayTrait::<felt252>::new()
+                space.contract_address, author, proposal_id, new_execution_strategy, array![]
             );
     }
 
@@ -238,7 +209,7 @@ mod tests {
         let authenticator = setup_stark_tx_auth(space, config.owner);
 
         let quorum = u256_from_felt252(1);
-        let mut constructor_calldata = ArrayTrait::<felt252>::new();
+        let mut constructor_calldata = array![];
         quorum.serialize(ref constructor_calldata);
 
         let (vanilla_execution_strategy_address, _) = deploy_syscall(
@@ -257,11 +228,7 @@ mod tests {
         testing::set_contract_address(author);
         authenticator
             .authenticate_propose(
-                space.contract_address,
-                author,
-                vanilla_execution_strategy,
-                ArrayTrait::<felt252>::new(),
-                ArrayTrait::<felt252>::new()
+                space.contract_address, author, vanilla_execution_strategy, array![], array![]
             );
 
         assert(
@@ -273,8 +240,7 @@ mod tests {
 
         let proposal_id = u256_from_felt252(1);
         // Keeping the same execution strategy contract but changing the payload
-        let mut new_payload = ArrayTrait::<felt252>::new();
-        new_payload.append(1);
+        let mut new_payload = array![1];
         let new_execution_strategy = Strategy {
             address: vanilla_execution_strategy_address, params: new_payload.clone()
         };
@@ -282,11 +248,7 @@ mod tests {
         testing::set_contract_address(author);
         authenticator
             .authenticate_update_proposal(
-                space.contract_address,
-                author,
-                proposal_id,
-                new_execution_strategy,
-                ArrayTrait::<felt252>::new()
+                space.contract_address, author, proposal_id, new_execution_strategy, array![]
             );
 
         // Increasing block timestamp by 1 to pass voting delay
@@ -294,20 +256,13 @@ mod tests {
 
         let voter = contract_address_const::<0x8765>();
         let choice = Choice::For(());
-        let mut user_voting_strategies = ArrayTrait::<IndexedStrategy>::new();
-        user_voting_strategies
-            .append(IndexedStrategy { index: 0_u8, params: ArrayTrait::<felt252>::new() });
+        let mut user_voting_strategies = array![IndexedStrategy { index: 0_u8, params: array![] }];
 
         // Vote on Proposal not from voter account
         testing::set_contract_address(config.owner);
         authenticator
             .authenticate_vote(
-                space.contract_address,
-                voter,
-                proposal_id,
-                choice,
-                user_voting_strategies,
-                ArrayTrait::<felt252>::new()
+                space.contract_address, voter, proposal_id, choice, user_voting_strategies, array![]
             );
     }
 }

--- a/starknet/src/tests/test_upgrade.cairo
+++ b/starknet/src/tests/test_upgrade.cairo
@@ -58,8 +58,8 @@ mod tests {
         };
 
         let author = UserAddress::Starknet(contract_address_const::<0x7777777777>());
-        let params = ArrayTrait::<felt252>::new();
-        let user_params = ArrayTrait::<felt252>::new();
+        let params = array![];
+        let user_params = array![];
         let res = new_space.validate(author, params, user_params);
         assert(res == false, 'Strategy did not return false');
     }
@@ -79,7 +79,7 @@ mod tests {
         let (execution_contract_address, _) = deploy_syscall(
             ExecutorExecutionStrategy::TEST_CLASS_HASH.try_into().unwrap(),
             0,
-            ArrayTrait::<felt252>::new().span(),
+            array![].span(),
             false
         )
             .unwrap();
@@ -90,18 +90,18 @@ mod tests {
 
         // keccak256("upgrade") & (2**250 - 1)
         let selector = 0xf2f7c15cbe06c8d94597cd91fd7f3369eae842359235712def5584f8d270cd;
-        let mut tx_calldata = ArrayTrait::new();
+        let mut tx_calldata = array![];
         new_implem.serialize(ref tx_calldata);
         let tx = Transaction { target: space.contract_address, selector, data: tx_calldata,  };
 
-        let mut execution_params = ArrayTrait::<felt252>::new();
+        let mut execution_params = array![];
         tx.serialize(ref execution_params);
 
         let execution_strategy = Strategy {
             address: execution_contract_address, params: execution_params.clone(), 
         };
 
-        let mut propose_calldata = ArrayTrait::<felt252>::new();
+        let mut propose_calldata = array![];
         UserAddress::Starknet(contract_address_const::<0x7676>()).serialize(ref propose_calldata);
         execution_strategy.serialize(ref propose_calldata);
         ArrayTrait::<felt252>::new().serialize(ref propose_calldata);
@@ -122,8 +122,8 @@ mod tests {
         };
 
         let author = UserAddress::Starknet(contract_address_const::<0x7777777777>());
-        let params = ArrayTrait::<felt252>::new();
-        let user_params = ArrayTrait::<felt252>::new();
+        let params = array![];
+        let user_params = array![];
         let res = new_space.validate(author, params, user_params);
         assert(res == false, 'Strategy did not return false');
     }

--- a/starknet/src/tests/utils/strategy_trait.cairo
+++ b/starknet/src/tests/utils/strategy_trait.cairo
@@ -9,12 +9,10 @@ trait StrategyTrait {
 
 impl StrategyImpl of StrategyTrait {
     fn test_value() -> Strategy {
-        Strategy {
-            address: contract_address_const::<0x5c011>(), params: ArrayTrait::<felt252>::new(), 
-        }
+        Strategy { address: contract_address_const::<0x5c011>(), params: array![],  }
     }
 
     fn from_address(addr: ContractAddress) -> Strategy {
-        Strategy { address: addr, params: ArrayTrait::<felt252>::new(),  }
+        Strategy { address: addr, params: array![],  }
     }
 }

--- a/starknet/src/types/strategy.cairo
+++ b/starknet/src/types/strategy.cairo
@@ -43,7 +43,7 @@ impl StoreFelt252Array of Store<Array<felt252>> {
     fn read_at_offset(
         address_domain: u32, base: StorageBaseAddress, mut offset: u8
     ) -> SyscallResult<Array<felt252>> {
-        let mut arr: Array<felt252> = ArrayTrait::new();
+        let mut arr = array![];
 
         // Read the stored array's length. If the length is superior to 255, the read will fail.
         let len: u8 = Store::<u8>::read_at_offset(address_domain, base, offset)

--- a/starknet/src/types/update_settings_calldata.cairo
+++ b/starknet/src/types/update_settings_calldata.cairo
@@ -69,7 +69,7 @@ impl NoUpdateStrategy of NoUpdateTrait<Strategy> {
     fn no_update() -> Strategy {
         Strategy {
             address: contract_address_const::<0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048>(),
-            params: array::ArrayTrait::new(),
+            params: array![],
         }
     }
 
@@ -82,7 +82,7 @@ impl NoUpdateStrategy of NoUpdateTrait<Strategy> {
 // TODO: find a way for "Strings"
 impl NoUpdateArray<T> of NoUpdateTrait<Array<T>> {
     fn no_update() -> Array<T> {
-        array::ArrayTrait::<T>::new()
+        array![]
     }
 
     fn should_update(self: @Array<T>) -> bool {

--- a/starknet/src/utils/merkle.cairo
+++ b/starknet/src/utils/merkle.cairo
@@ -21,7 +21,7 @@ trait Hash<T> {
 
 impl HashSerde<T, impl TSerde: Serde<T>> of Hash<T> {
     fn hash(self: @T) -> felt252 {
-        let mut serialized = ArrayTrait::new();
+        let mut serialized = array![];
         Serde::<T>::serialize(self, ref serialized);
         let hashed = LegacyHash::hash(0, serialized.span());
         hashed

--- a/starknet/src/utils/signatures.cairo
+++ b/starknet/src/utils/signatures.cairo
@@ -32,10 +32,11 @@ trait KeccakTypeHash<T> {
 
 impl KeccakTypeHashStrategy of KeccakTypeHash<Strategy> {
     fn hash(self: Strategy) -> u256 {
-        let mut encoded_data = ArrayTrait::<u256>::new();
-        encoded_data.append(u256 { low: STRATEGY_TYPEHASH_LOW, high: STRATEGY_TYPEHASH_HIGH });
-        encoded_data.append(self.address.into());
-        encoded_data.append(self.params.hash());
+        let mut encoded_data = array![
+            u256 {
+                low: STRATEGY_TYPEHASH_LOW, high: STRATEGY_TYPEHASH_HIGH
+            }, self.address.into(), self.params.hash(),
+        ];
         keccak::keccak_u256s_le_inputs(encoded_data.span())
     }
 }
@@ -51,14 +52,12 @@ impl KeccakTypeHashArray of KeccakTypeHash<Array<felt252>> {
 
 impl KeccakTypeHashIndexedStrategy of KeccakTypeHash<IndexedStrategy> {
     fn hash(self: IndexedStrategy) -> u256 {
-        let mut encoded_data = ArrayTrait::<u256>::new();
-        encoded_data
-            .append(
-                u256 { low: INDEXED_STRATEGY_TYPEHASH_LOW, high: INDEXED_STRATEGY_TYPEHASH_HIGH }
-            );
         let index_felt: felt252 = self.index.into();
-        encoded_data.append(index_felt.into());
-        encoded_data.append(self.params.hash());
+        let mut encoded_data = array![
+            u256 {
+                low: INDEXED_STRATEGY_TYPEHASH_LOW, high: INDEXED_STRATEGY_TYPEHASH_HIGH
+            }, index_felt.into(), self.params.hash(),
+        ];
         keccak::keccak_u256s_le_inputs(encoded_data.span())
     }
 }
@@ -143,13 +142,16 @@ fn get_propose_digest(
     user_proposal_validation_params: Array<felt252>,
     salt: u256
 ) -> u256 {
-    let mut encoded_data = ArrayTrait::<u256>::new();
-    encoded_data.append(u256 { low: PROPOSE_TYPEHASH_LOW, high: PROPOSE_TYPEHASH_HIGH });
-    encoded_data.append(space.into());
-    encoded_data.append(author.into());
-    encoded_data.append(execution_strategy.hash());
-    encoded_data.append(user_proposal_validation_params.hash());
-    encoded_data.append(salt);
+    let mut encoded_data = array![
+        u256 {
+            low: PROPOSE_TYPEHASH_LOW, high: PROPOSE_TYPEHASH_HIGH
+        },
+        space.into(),
+        author.into(),
+        execution_strategy.hash(),
+        user_proposal_validation_params.hash(),
+        salt,
+    ];
     let message_hash = keccak::keccak_u256s_le_inputs(encoded_data.span());
     hash_typed_data(domain_hash, message_hash)
 }
@@ -162,13 +164,11 @@ fn get_vote_digest(
     choice: Choice,
     user_voting_strategies: Array<IndexedStrategy>
 ) -> u256 {
-    let mut encoded_data = ArrayTrait::<u256>::new();
-    encoded_data.append(u256 { low: VOTE_TYPEHASH_LOW, high: VOTE_TYPEHASH_HIGH });
-    encoded_data.append(space.into());
-    encoded_data.append(voter.into());
-    encoded_data.append(proposal_id);
-    encoded_data.append(choice.into());
-    encoded_data.append(user_voting_strategies.hash());
+    let mut encoded_data = array![
+        u256 {
+            low: VOTE_TYPEHASH_LOW, high: VOTE_TYPEHASH_HIGH
+        }, space.into(), voter.into(), proposal_id, choice.into(), user_voting_strategies.hash(),
+    ];
     let message_hash = keccak::keccak_u256s_le_inputs(encoded_data.span());
     hash_typed_data(domain_hash, message_hash)
 }
@@ -181,33 +181,32 @@ fn get_update_proposal_digest(
     execution_strategy: Strategy,
     salt: u256
 ) -> u256 {
-    let mut encoded_data = ArrayTrait::<u256>::new();
-    encoded_data
-        .append(u256 { low: UPDATE_PROPOSAL_TYPEHASH_LOW, high: UPDATE_PROPOSAL_TYPEHASH_HIGH });
-    encoded_data.append(space.into());
-    encoded_data.append(author.into());
-    encoded_data.append(proposal_id);
-    encoded_data.append(execution_strategy.hash());
-    encoded_data.append(salt);
+    let mut encoded_data = array![
+        u256 {
+            low: UPDATE_PROPOSAL_TYPEHASH_LOW, high: UPDATE_PROPOSAL_TYPEHASH_HIGH
+        }, space.into(), author.into(), proposal_id, execution_strategy.hash(), salt,
+    ];
     let message_hash = keccak::keccak_u256s_le_inputs(encoded_data.span());
     hash_typed_data(domain_hash, message_hash)
 }
 
 fn get_domain_hash(name: felt252, version: felt252) -> u256 {
-    let mut encoded_data = ArrayTrait::<u256>::new();
-    encoded_data.append(u256 { low: DOMAIN_TYPEHASH_LOW, high: DOMAIN_TYPEHASH_HIGH });
-    encoded_data.append(name.into());
-    encoded_data.append(version.into());
-    // TODO: chain id doesnt seem like its exposed atm, so just dummy value for now
-    encoded_data.append(u256 { low: 'dummy', high: 0 });
-    encoded_data.append(starknet::get_contract_address().into());
+    let mut encoded_data = array![
+        u256 {
+            low: DOMAIN_TYPEHASH_LOW, high: DOMAIN_TYPEHASH_HIGH
+            },
+            name.into(),
+            version
+                .into(), // TODO: chain id doesnt seem like its exposed atm, so just dummy value for now
+            u256 {
+            low: 'dummy', high: 0
+        }, starknet::get_contract_address().into(),
+    ];
     keccak::keccak_u256s_le_inputs(encoded_data.span())
 }
 
 fn hash_typed_data(domain_hash: u256, message_hash: u256) -> u256 {
-    let mut encoded_data = ArrayTrait::<u256>::new();
-    encoded_data.append(domain_hash);
-    encoded_data.append(message_hash);
+    let mut encoded_data = array![domain_hash, message_hash, ];
     let encoded_data = _add_prefix_array(encoded_data, ETHEREUM_PREFIX);
     keccak::keccak_u256s_le_inputs(encoded_data.span())
 }
@@ -215,7 +214,7 @@ fn hash_typed_data(domain_hash: u256, message_hash: u256) -> u256 {
 
 // Prefixes a 16 bit prefix to an array of 256 bit values.
 fn _add_prefix_array(input: Array<u256>, mut prefix: u128) -> Array<u256> {
-    let mut out = ArrayTrait::<u256>::new();
+    let mut out = array![];
     let mut i = 0_usize;
     loop {
         if i >= input.len() {

--- a/starknet/src/utils/single_slot_proof.cairo
+++ b/starknet/src/utils/single_slot_proof.cairo
@@ -56,9 +56,7 @@ mod SingleSlotProof {
 
     #[internal]
     fn get_mapping_slot_key(slot_index: u256, mapping_key: u256) -> u256 {
-        let mut encoded_array = ArrayTrait::<u256>::new();
-        encoded_array.append(mapping_key);
-        encoded_array.append(slot_index);
+        let mut encoded_array = array![mapping_key, slot_index];
         keccak::keccak_u256s_le_inputs(encoded_array.span())
     }
 

--- a/starknet/src/utils/stark_eip712.cairo
+++ b/starknet/src/utils/stark_eip712.cairo
@@ -84,7 +84,7 @@ fn get_propose_digest(
     metadata_URI: Span<felt252>,
     salt: felt252
 ) -> felt252 {
-    let mut encoded_data = ArrayTrait::<felt252>::new();
+    let mut encoded_data = array![];
     PROPOSE_TYPEHASH.serialize(ref encoded_data);
     space.serialize(ref encoded_data);
     author.serialize(ref encoded_data);
@@ -104,7 +104,7 @@ fn get_vote_digest(
     user_voting_strategies: Span<IndexedStrategy>,
     metadata_URI: Span<felt252>,
 ) -> felt252 {
-    let mut encoded_data = ArrayTrait::<felt252>::new();
+    let mut encoded_data = array![];
     VOTE_TYPEHASH.serialize(ref encoded_data);
     space.serialize(ref encoded_data);
     voter.serialize(ref encoded_data);
@@ -124,7 +124,7 @@ fn get_update_proposal_digest(
     metadata_URI: Span<felt252>,
     salt: felt252
 ) -> felt252 {
-    let mut encoded_data = ArrayTrait::<felt252>::new();
+    let mut encoded_data = array![];
     UPDATE_PROPOSAL_TYPEHASH.serialize(ref encoded_data);
     space.serialize(ref encoded_data);
     author.serialize(ref encoded_data);
@@ -136,7 +136,7 @@ fn get_update_proposal_digest(
 }
 
 fn get_domain_hash(name: felt252, version: felt252) -> felt252 {
-    let mut encoded_data = ArrayTrait::<felt252>::new();
+    let mut encoded_data = array![];
     DOMAIN_TYPEHASH.serialize(ref encoded_data);
     name.serialize(ref encoded_data);
     version.serialize(ref encoded_data);
@@ -148,7 +148,7 @@ fn get_domain_hash(name: felt252, version: felt252) -> felt252 {
 fn hash_typed_data(
     domain_hash: felt252, message_hash: felt252, signer: ContractAddress
 ) -> felt252 {
-    let mut encoded_data = ArrayTrait::<felt252>::new();
+    let mut encoded_data = array![];
     STARKNET_MESSAGE.serialize(ref encoded_data);
     domain_hash.serialize(ref encoded_data);
     signer.serialize(ref encoded_data);

--- a/starknet/src/utils/struct_hash.cairo
+++ b/starknet/src/utils/struct_hash.cairo
@@ -24,7 +24,7 @@ impl StructHashSpanFelt252 of StructHash<Span<felt252>> {
 
 impl StructHashStrategy of StructHash<Strategy> {
     fn struct_hash(self: @Strategy) -> felt252 {
-        let mut encoded_data = ArrayTrait::<felt252>::new();
+        let mut encoded_data = array![];
         STRATEGY_TYPEHASH.serialize(ref encoded_data);
         (*self.address).serialize(ref encoded_data);
         self.params.span().struct_hash().serialize(ref encoded_data);
@@ -34,7 +34,7 @@ impl StructHashStrategy of StructHash<Strategy> {
 
 impl StructHashIndexedStrategy of StructHash<IndexedStrategy> {
     fn struct_hash(self: @IndexedStrategy) -> felt252 {
-        let mut encoded_data = ArrayTrait::<felt252>::new();
+        let mut encoded_data = array![];
         INDEXED_STRATEGY_TYPEHASH.serialize(ref encoded_data);
         (*self.index).serialize(ref encoded_data);
         self.params.span().struct_hash().serialize(ref encoded_data);
@@ -45,7 +45,7 @@ impl StructHashIndexedStrategy of StructHash<IndexedStrategy> {
 impl StructHashIndexedStrategySpan of StructHash<Span<IndexedStrategy>> {
     fn struct_hash(self: @Span<IndexedStrategy>) -> felt252 {
         let mut self_ = *self;
-        let mut encoded_data = ArrayTrait::<felt252>::new();
+        let mut encoded_data = array![];
         loop {
             match self_.pop_front() {
                 Option::Some(item) => {
@@ -61,7 +61,7 @@ impl StructHashIndexedStrategySpan of StructHash<Span<IndexedStrategy>> {
 
 impl StructHashU256 of StructHash<u256> {
     fn struct_hash(self: @u256) -> felt252 {
-        let mut encoded_data = ArrayTrait::<felt252>::new();
+        let mut encoded_data = array![];
         U256_TYPEHASH.serialize(ref encoded_data);
         self.serialize(ref encoded_data);
         encoded_data.span().struct_hash()


### PR DESCRIPTION
Some places had to keep `Array::<felt252>::new()` (most notably, when serialize is called right after AND the array is later on serialized into another array) because the type can't be inferred :)

Closes #479 

