### PR TITLE
Fix erc20 proposition strategy

### DIFF
--- a/starknet/src/types/proposal.cairo
+++ b/starknet/src/types/proposal.cairo
@@ -8,7 +8,6 @@ use sx::utils::math::pow;
 use traits::{Into, TryInto};
 use sx::types::{FinalizationStatus, UserAddress};
 use option::OptionTrait;
-use debug::PrintTrait;
 
 const BITMASK_32: u128 = 0xffffffff;
 const BITMASK_64: u128 = 0xffffffffffffffff;

--- a/starknet/src/utils/proposition_power.cairo
+++ b/starknet/src/utils/proposition_power.cairo
@@ -60,7 +60,7 @@ fn _validate(
     let user_strategies = Serde::<Array<IndexedStrategy>>::deserialize(ref user_params_span)
         .unwrap();
 
-    let timestamp: u32 = info::get_block_timestamp().try_into().unwrap();
+    let timestamp: u32 = info::get_block_timestamp().try_into().unwrap() - 1;
     let voting_power = _get_cumulative_power(
         author, timestamp, user_strategies, allowed_strategies
     );

--- a/starknet/src/utils/proposition_power.cairo
+++ b/starknet/src/utils/proposition_power.cairo
@@ -14,7 +14,7 @@ use clone::Clone;
 
 fn _get_cumulative_power(
     voter: UserAddress,
-    block_number: u32,
+    timestamp: u32,
     mut user_strategies: Array<IndexedStrategy>,
     allowed_strategies: Array<Strategy>,
 ) -> u256 {
@@ -30,7 +30,7 @@ fn _get_cumulative_power(
                             contract_address: strategy.address
                         }
                             .get_voting_power(
-                                block_number, voter, strategy.params, indexed_strategy.params, 
+                                timestamp, voter, strategy.params, indexed_strategy.params, 
                             );
                     },
                     Option::None => {


### PR DESCRIPTION
- Use `timestamp - 1` for proposing power proposal validation strategy
- Add test to ensure it's working correctly
- Fix naming in `get_voting_power` (used `block_number` instead of `timestamp`)