### PR TITLE
Remove useless imports

### DIFF
--- a/starknet/src/authenticators/eth_sig.cairo
+++ b/starknet/src/authenticators/eth_sig.cairo
@@ -45,14 +45,11 @@ trait IEthSigAuthenticator<TContractState> {
 mod EthSigAuthenticator {
     use super::IEthSigAuthenticator;
     use starknet::{ContractAddress, EthAddress, syscalls::call_contract_syscall};
-    use core::array::{ArrayTrait, SpanTrait};
-    use clone::Clone;
     use sx::{
         space::space::{ISpaceDispatcher, ISpaceDispatcherTrait},
         types::{Strategy, IndexedStrategy, Choice, UserAddress},
         utils::{signatures, legacy_hash::{LegacyHashEthAddress, LegacyHashUsedSalts}}
     };
-    use hash::LegacyHash;
 
 
     #[storage]

--- a/starknet/src/authenticators/eth_tx.cairo
+++ b/starknet/src/authenticators/eth_tx.cairo
@@ -35,10 +35,6 @@ trait IEthTxAuthenticator<TContractState> {
 mod EthTxAuthenticator {
     use super::IEthTxAuthenticator;
     use starknet::{ContractAddress, EthAddress, Felt252TryIntoEthAddress, EthAddressIntoFelt252,};
-    use core::{serde::Serde, array::{ArrayTrait, SpanTrait}};
-    use traits::{PartialEq, TryInto, Into};
-    use option::OptionTrait;
-    use zeroable::Zeroable;
     use sx::{
         space::space::{ISpaceDispatcher, ISpaceDispatcherTrait},
         types::{UserAddress, Strategy, IndexedStrategy, Choice},

--- a/starknet/src/authenticators/stark_sig.cairo
+++ b/starknet/src/authenticators/stark_sig.cairo
@@ -42,8 +42,6 @@ trait IStarkSigAuthenticator<TContractState> {
 mod StarkSigAuthenticator {
     use super::IStarkSigAuthenticator;
     use starknet::{ContractAddress, info};
-    use core::array::{ArrayTrait, SpanTrait};
-    use serde::Serde;
     use sx::{
         space::space::{ISpaceDispatcher, ISpaceDispatcherTrait},
         types::{Strategy, IndexedStrategy, UserAddress, Choice}, utils::stark_eip712

--- a/starknet/src/authenticators/stark_tx.cairo
+++ b/starknet/src/authenticators/stark_tx.cairo
@@ -34,7 +34,6 @@ trait IStarkTxAuthenticator<TContractState> {
 mod StarkTxAuthenticator {
     use super::IStarkTxAuthenticator;
     use starknet::{ContractAddress, info};
-    use core::array::ArrayTrait;
     use sx::{
         space::space::{ISpaceDispatcher, ISpaceDispatcherTrait},
         types::{UserAddress, Strategy, IndexedStrategy, Choice},

--- a/starknet/src/authenticators/vanilla.cairo
+++ b/starknet/src/authenticators/vanilla.cairo
@@ -12,7 +12,6 @@ mod VanillaAuthenticator {
     use super::IVanillaAuthenticator;
     use starknet::ContractAddress;
     use starknet::syscalls::call_contract_syscall;
-    use core::array::{ArrayTrait, SpanTrait};
 
     #[storage]
     struct Storage {}

--- a/starknet/src/execution_strategies/simple_quorum.cairo
+++ b/starknet/src/execution_strategies/simple_quorum.cairo
@@ -1,12 +1,9 @@
 use core::traits::TryInto;
 #[starknet::contract]
 mod SimpleQuorumExecutionStrategy {
-    use traits::TryInto;
-    use option::OptionTrait;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
     use starknet::info;
-    use zeroable::Zeroable;
     use sx::types::{Proposal, FinalizationStatus, ProposalStatus};
 
     #[storage]

--- a/starknet/src/execution_strategies/vanilla.cairo
+++ b/starknet/src/execution_strategies/vanilla.cairo
@@ -4,7 +4,6 @@ mod VanillaExecutionStrategy {
     use sx::types::{Proposal, ProposalStatus};
     use sx::execution_strategies::simple_quorum::SimpleQuorumExecutionStrategy;
 
-
     #[storage]
     struct Storage {
         _num_executed: felt252

--- a/starknet/src/external/ownable.cairo
+++ b/starknet/src/external/ownable.cairo
@@ -3,7 +3,6 @@
 #[starknet::contract]
 mod Ownable {
     use starknet::{ContractAddress, get_caller_address};
-    use zeroable::Zeroable;
 
     #[storage]
     struct Storage {

--- a/starknet/src/factory/factory.cairo
+++ b/starknet/src/factory/factory.cairo
@@ -18,8 +18,6 @@ mod Factory {
         ContractAddress, ClassHash, contract_address_const,
         syscalls::{deploy_syscall, call_contract_syscall}
     };
-    use result::ResultTrait;
-    use array::{ArrayTrait, SpanTrait};
     use sx::utils::constants::INITIALIZE_SELECTOR;
 
     #[event]

--- a/starknet/src/interfaces/i_account.cairo
+++ b/starknet/src/interfaces/i_account.cairo
@@ -1,4 +1,3 @@
-use array::{ArrayTrait, SpanTrait};
 use starknet::account::Call;
 use starknet::ContractAddress;
 

--- a/starknet/src/interfaces/i_execution_strategy.cairo
+++ b/starknet/src/interfaces/i_execution_strategy.cairo
@@ -1,4 +1,3 @@
-use array::ArrayTrait;
 use sx::types::Proposal;
 
 #[starknet::interface]

--- a/starknet/src/proposal_validation_strategies/proposing_power.cairo
+++ b/starknet/src/proposal_validation_strategies/proposing_power.cairo
@@ -8,13 +8,6 @@ mod ProposingPowerProposalValidationStrategy {
         utils::{bits::BitSetter, proposition_power::_validate}
     };
     use starknet::{ContractAddress, info};
-    use traits::{Into, TryInto};
-    use option::OptionTrait;
-    use result::ResultTrait;
-    use array::{ArrayTrait, SpanTrait};
-    use serde::Serde;
-    use box::BoxTrait;
-    use clone::Clone;
 
     #[storage]
     struct Storage {}

--- a/starknet/src/space/space.cairo
+++ b/starknet/src/space/space.cairo
@@ -1,5 +1,3 @@
-use core::traits::TryInto;
-use core::traits::Destruct;
 use starknet::{ClassHash, ContractAddress};
 use sx::types::{UserAddress, Strategy, Proposal, IndexedStrategy, Choice, UpdateSettingsCalldata};
 
@@ -79,12 +77,6 @@ mod Space {
         storage_access::{StorePacking, StoreUsingPacking}, ClassHash, ContractAddress, info, Store,
         syscalls
     };
-    use zeroable::Zeroable;
-    use array::{ArrayTrait, SpanTrait};
-    use clone::Clone;
-    use option::OptionTrait;
-    use hash::LegacyHash;
-    use traits::{Into, TryInto};
     use sx::{
         interfaces::{
             IProposalValidationStrategyDispatcher, IProposalValidationStrategyDispatcherTrait,
@@ -105,7 +97,6 @@ mod Space {
         },
         external::ownable::Ownable
     };
-    use hash::{HashStateTrait, Hash, HashStateExTrait};
 
 
     #[storage]

--- a/starknet/src/tests/mocks/executor.cairo
+++ b/starknet/src/tests/mocks/executor.cairo
@@ -3,9 +3,6 @@ mod ExecutorExecutionStrategy {
     use sx::interfaces::IExecutionStrategy;
     use sx::types::{Proposal, ProposalStatus};
     use starknet::ContractAddress;
-    use core::serde::Serde;
-    use core::array::ArrayTrait;
-    use option::OptionTrait;
     use starknet::syscalls::call_contract_syscall;
 
     #[storage]

--- a/starknet/src/tests/proposal_validation_strategies/proposing_power.cairo
+++ b/starknet/src/tests/proposal_validation_strategies/proposing_power.cairo
@@ -6,27 +6,23 @@ mod tests {
     use starknet::ContractAddress;
     use sx::{
         voting_strategies::{
-            vanilla::VanillaVotingStrategy,
-            merkle_whitelist::MerkleWhitelistVotingStrategy,
+            vanilla::VanillaVotingStrategy, merkle_whitelist::MerkleWhitelistVotingStrategy,
             erc20_votes::ERC20VotesVotingStrategy
         },
-        utils::{
-            merkle::Leaf
-        },
-        proposal_validation_strategies::proposing_power::{
-            ProposingPowerProposalValidationStrategy
-        },
+        utils::{merkle::Leaf},
+        proposal_validation_strategies::proposing_power::{ProposingPowerProposalValidationStrategy},
         interfaces::{
-        IProposalValidationStrategy, IProposalValidationStrategyDispatcher,
-        IProposalValidationStrategyDispatcherTrait
-    },
-    types::{IndexedStrategy, Strategy, UserAddress},
-    tests::{
-        test_merkle_whitelist::merkle_utils::{
-            generate_merkle_data, generate_merkle_root, generate_proof
+            IProposalValidationStrategy, IProposalValidationStrategyDispatcher,
+            IProposalValidationStrategyDispatcherTrait
         },
-        mocks::erc20_votes_preset::ERC20VotesPreset
-    }};
+        types::{IndexedStrategy, Strategy, UserAddress},
+        tests::{
+            test_merkle_whitelist::merkle_utils::{
+                generate_merkle_data, generate_merkle_root, generate_proof
+            },
+            mocks::erc20_votes_preset::ERC20VotesPreset
+        }
+    };
     use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
     use openzeppelin::governance::utils::interfaces::votes::{
         IVotes, IVotesDispatcher, IVotesDispatcherTrait

--- a/starknet/src/tests/proposal_validation_strategies/proposing_power.cairo
+++ b/starknet/src/tests/proposal_validation_strategies/proposing_power.cairo
@@ -1,36 +1,36 @@
 #[cfg(test)]
 mod tests {
     use starknet::syscalls::deploy_syscall;
-    use traits::{TryInto};
     use starknet::SyscallResult;
-    use array::{ArrayTrait, SpanTrait};
-    use result::ResultTrait;
-    use option::OptionTrait;
-    use sx::voting_strategies::vanilla::{VanillaVotingStrategy};
-    use sx::voting_strategies::merkle_whitelist::{MerkleWhitelistVotingStrategy};
-    use sx::utils::merkle::Leaf;
-    use sx::proposal_validation_strategies::proposing_power::{
-        ProposingPowerProposalValidationStrategy
-    };
-    use sx::interfaces::{
+    use starknet::contract_address_const;
+    use starknet::ContractAddress;
+    use sx::{
+        voting_strategies::{
+            vanilla::VanillaVotingStrategy,
+            merkle_whitelist::MerkleWhitelistVotingStrategy,
+            erc20_votes::ERC20VotesVotingStrategy
+        },
+        utils::{
+            merkle::Leaf
+        },
+        proposal_validation_strategies::proposing_power::{
+            ProposingPowerProposalValidationStrategy
+        },
+        interfaces::{
         IProposalValidationStrategy, IProposalValidationStrategyDispatcher,
         IProposalValidationStrategyDispatcherTrait
-    };
-    use sx::types::{IndexedStrategy, Strategy, UserAddress};
-    use serde::Serde;
-    use starknet::contract_address_const;
-    use clone::Clone;
-    use sx::tests::test_merkle_whitelist::merkle_utils::{
-        generate_merkle_data, generate_merkle_root, generate_proof
-    };
-    use sx::tests::mocks::erc20_votes_preset::{ERC20VotesPreset};
+    },
+    types::{IndexedStrategy, Strategy, UserAddress},
+    tests::{
+        test_merkle_whitelist::merkle_utils::{
+            generate_merkle_data, generate_merkle_root, generate_proof
+        },
+        mocks::erc20_votes_preset::ERC20VotesPreset
+    }};
     use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
     use openzeppelin::governance::utils::interfaces::votes::{
         IVotes, IVotesDispatcher, IVotesDispatcherTrait
     };
-    use traits::Into;
-    use sx::voting_strategies::erc20_votes::ERC20VotesVotingStrategy;
-    use starknet::ContractAddress;
 
     #[test]
     #[available_gas(10000000000)]

--- a/starknet/src/tests/setup/setup.cairo
+++ b/starknet/src/tests/setup/setup.cairo
@@ -1,11 +1,6 @@
 #[cfg(test)]
 mod setup {
-    use array::ArrayTrait;
     use starknet::{ContractAddress, contract_address_const};
-    use traits::{Into, TryInto};
-    use serde::{Serde};
-    use result::ResultTrait;
-    use option::OptionTrait;
     use sx::types::Strategy;
     use sx::authenticators::vanilla::{VanillaAuthenticator};
     use sx::execution_strategies::vanilla::VanillaExecutionStrategy;

--- a/starknet/src/tests/utils/strategy_trait.cairo
+++ b/starknet/src/tests/utils/strategy_trait.cairo
@@ -1,4 +1,3 @@
-use array::ArrayTrait;
 use sx::types::Strategy;
 use starknet::{ContractAddress, contract_address_const};
 

--- a/starknet/src/tests/voting_strategies/erc20_votes.cairo
+++ b/starknet/src/tests/voting_strategies/erc20_votes.cairo
@@ -13,10 +13,6 @@ mod tests {
     use sx::tests::setup::setup::setup::{setup as _setup, deploy, Config};
     use starknet::syscalls::deploy_syscall;
     use starknet::SyscallResult;
-    use result::ResultTrait;
-    use option::OptionTrait;
-    use traits::{Into, TryInto};
-    use array::{ArrayTrait, SpanTrait};
     use sx::interfaces::{
         IVotingStrategy, IVotingStrategyDispatcher, IVotingStrategyDispatcherTrait
     };
@@ -31,7 +27,6 @@ mod tests {
     use sx::tests::utils::strategy_trait::StrategyImpl;
     use sx::utils::constants::{PROPOSE_SELECTOR, VOTE_SELECTOR};
     use sx::execution_strategies::vanilla::VanillaExecutionStrategy;
-    use serde::Serde;
 
     const NAME: felt252 = 'TEST';
     const SYMBOL: felt252 = 'TST';

--- a/starknet/src/types/choice.cairo
+++ b/starknet/src/types/choice.cairo
@@ -1,7 +1,3 @@
-use serde::Serde;
-use traits::Into;
-use hash::LegacyHash;
-
 #[derive(Copy, Drop, Serde)]
 enum Choice {
     Against: (),

--- a/starknet/src/types/finalization_status.cairo
+++ b/starknet/src/types/finalization_status.cairo
@@ -1,6 +1,3 @@
-use serde::Serde;
-use array::ArrayTrait;
-
 #[derive(Drop, Serde, PartialEq, Copy, starknet::Store)]
 enum FinalizationStatus {
     Pending: (),

--- a/starknet/src/types/indexed_strategy.cairo
+++ b/starknet/src/types/indexed_strategy.cairo
@@ -1,8 +1,3 @@
-use core::array::SpanTrait;
-use option::OptionTrait;
-use serde::Serde;
-use clone::Clone;
-use array::ArrayTrait;
 use sx::utils::math;
 
 #[derive(Option, Clone, Drop, Serde)]

--- a/starknet/src/types/proposal.cairo
+++ b/starknet/src/types/proposal.cairo
@@ -1,11 +1,7 @@
-use clone::Clone;
-use serde::Serde;
 use starknet::{ContractAddress, storage_access::StorePacking, Store};
 use sx::{
     utils::math::pow, types::{FinalizationStatus, UserAddress, user_address::UserAddressTrait}
 };
-use traits::{Into, TryInto};
-use option::OptionTrait;
 
 const BITMASK_32: u128 = 0xffffffff;
 const BITMASK_64: u128 = 0xffffffffffffffff;

--- a/starknet/src/types/proposal_status.cairo
+++ b/starknet/src/types/proposal_status.cairo
@@ -1,5 +1,3 @@
-use serde::Serde;
-
 #[derive(Copy, Drop, Serde, PartialEq)]
 enum ProposalStatus {
     VotingDelay: (),

--- a/starknet/src/types/strategy.cairo
+++ b/starknet/src/types/strategy.cairo
@@ -1,10 +1,4 @@
 use starknet::ContractAddress;
-use array::ArrayTrait;
-use serde::Serde;
-use option::OptionTrait;
-use clone::Clone;
-use result::ResultTrait;
-use traits::TryInto;
 use starknet::{StorageBaseAddress, Store, SyscallResult};
 
 #[derive(Clone, Drop, Option, Serde, starknet::Store)]

--- a/starknet/src/types/update_settings_calldata.cairo
+++ b/starknet/src/types/update_settings_calldata.cairo
@@ -1,5 +1,3 @@
-use array::ArrayTrait;
-use clone::Clone;
 use starknet::{ContractAddress, contract_address_const};
 use sx::types::Strategy;
 

--- a/starknet/src/types/user_address.cairo
+++ b/starknet/src/types/user_address.cairo
@@ -1,9 +1,4 @@
 use starknet::{ContractAddress, EthAddress};
-use traits::{PartialEq, TryInto, Into};
-use zeroable::Zeroable;
-use serde::Serde;
-use array::ArrayTrait;
-use hash::{LegacyHash};
 
 #[derive(Copy, Drop, Serde, PartialEq, starknet::Store)]
 enum UserAddress {
@@ -79,7 +74,6 @@ impl UserAddressZeroable of Zeroable<UserAddress> {
 
 #[cfg(test)]
 mod tests {
-    use zeroable::Zeroable;
     use super::{UserAddress, UserAddressZeroable};
     use starknet::{EthAddress, contract_address_const};
 

--- a/starknet/src/utils/bits.cairo
+++ b/starknet/src/utils/bits.cairo
@@ -1,5 +1,3 @@
-use traits::{Into};
-use zeroable::Zeroable;
 use integer::{Bitwise, U256BitOr, U256BitNot, U128IntoFelt252, Felt252IntoU256, BoundedInt};
 use sx::utils::math::pow;
 

--- a/starknet/src/utils/felt_arr_to_uint_arr.cairo
+++ b/starknet/src/utils/felt_arr_to_uint_arr.cairo
@@ -1,6 +1,3 @@
-use array::ArrayTrait;
-use traits::Into;
-
 impl Felt252ArrayIntoU256Array of Into<Array<felt252>, Array<u256>> {
     fn into(mut self: Array<felt252>) -> Array<u256> {
         let mut arr = array![];

--- a/starknet/src/utils/legacy_hash.cairo
+++ b/starknet/src/utils/legacy_hash.cairo
@@ -1,6 +1,4 @@
 use hash::LegacyHash;
-use traits::Into;
-use array::SpanTrait;
 use starknet::EthAddress;
 use sx::types::{Choice, UserAddress};
 

--- a/starknet/src/utils/math.cairo
+++ b/starknet/src/utils/math.cairo
@@ -1,6 +1,3 @@
-use zeroable::Zeroable;
-use traits::Into;
-
 impl U64Zeroable of Zeroable<u64> {
     fn zero() -> u64 {
         0

--- a/starknet/src/utils/merkle.cairo
+++ b/starknet/src/utils/merkle.cairo
@@ -1,8 +1,3 @@
-use core::traits::Into;
-use array::{ArrayTrait, Span, SpanTrait};
-use option::OptionTrait;
-use serde::Serde;
-use clone::Clone;
 use hash::{LegacyHash};
 use sx::{types::UserAddress, utils::legacy_hash::LegacyHashSpanFelt252};
 

--- a/starknet/src/utils/proposition_power.cairo
+++ b/starknet/src/utils/proposition_power.cairo
@@ -5,13 +5,6 @@ use sx::{
     types::{UserAddress, IndexedStrategy, IndexedStrategyTrait, Strategy}, utils::bits::BitSetter
 };
 use starknet::{ContractAddress, info};
-use traits::{Into, TryInto};
-use option::OptionTrait;
-use result::ResultTrait;
-use array::{ArrayTrait, SpanTrait};
-use serde::Serde;
-use box::BoxTrait;
-use clone::Clone;
 
 fn _get_cumulative_power(
     voter: UserAddress,

--- a/starknet/src/utils/signatures.cairo
+++ b/starknet/src/utils/signatures.cairo
@@ -1,8 +1,4 @@
 use starknet::{EthAddress, ContractAddress, secp256_trait, contract_address_to_felt252};
-use array::{ArrayTrait, SpanTrait};
-use traits::Into;
-use clone::Clone;
-use core::keccak;
 use integer::u256_from_felt252;
 use sx::{
     types::{Strategy, IndexedStrategy, Choice},

--- a/starknet/src/utils/stark_eip712.cairo
+++ b/starknet/src/utils/stark_eip712.cairo
@@ -1,9 +1,5 @@
 use core::starknet::SyscallResultTrait;
 use starknet::{ContractAddress, get_tx_info, get_contract_address};
-use array::{ArrayTrait, SpanTrait};
-use traits::Into;
-use box::BoxTrait;
-use serde::Serde;
 use sx::{
     types::{Strategy, IndexedStrategy, Choice},
     utils::{

--- a/starknet/src/utils/struct_hash.cairo
+++ b/starknet/src/utils/struct_hash.cairo
@@ -1,6 +1,4 @@
-use array::{ArrayTrait, SpanTrait};
 use hash::LegacyHash;
-use serde::Serde;
 use sx::{
     types::{Strategy, IndexedStrategy},
     utils::{

--- a/starknet/src/voting_strategies/erc20_votes.cairo
+++ b/starknet/src/voting_strategies/erc20_votes.cairo
@@ -1,17 +1,11 @@
-use sx::types::user_address::UserAddressTrait;
 #[starknet::contract]
 mod ERC20VotesVotingStrategy {
     use sx::interfaces::IVotingStrategy;
     use sx::types::{UserAddress, UserAddressTrait};
     use starknet::ContractAddress;
-    use serde::Serde;
-    use array::{ArrayTrait, SpanTrait};
     use openzeppelin::governance::utils::interfaces::votes::{
         IVotes, IVotesDispatcher, IVotesDispatcherTrait
     };
-    use traits::Into;
-
-    use option::OptionTrait;
 
     #[storage]
     struct Storage {}

--- a/starknet/src/voting_strategies/eth_balance_of.cairo
+++ b/starknet/src/voting_strategies/eth_balance_of.cairo
@@ -1,6 +1,5 @@
 #[starknet::contract]
 mod EthBalanceOfVotingStrategy {
-    use traits::Into;
     use starknet::{EthAddress, ContractAddress};
     use sx::{
         interfaces::IVotingStrategy, types::{UserAddress, UserAddressTrait},

--- a/starknet/src/voting_strategies/merkle_whitelist.cairo
+++ b/starknet/src/voting_strategies/merkle_whitelist.cairo
@@ -3,9 +3,6 @@ mod MerkleWhitelistVotingStrategy {
     use sx::{
         interfaces::IVotingStrategy, types::UserAddress, utils::merkle::{assert_valid_proof, Leaf}
     };
-    use serde::Serde;
-    use array::{ArrayTrait, Span, SpanTrait};
-    use option::OptionTrait;
 
     const LEAF_SIZE: usize = 4; // Serde::<Leaf>::serialize().len()
 


### PR DESCRIPTION
`v2.2.0` of Cairo allows us to remove a lot of useless `use` lines :)