### PR TITLE
refactor: array hashing

### DIFF
--- a/starknet/src/utils/legacy_hash.cairo
+++ b/starknet/src/utils/legacy_hash.cairo
@@ -17,6 +17,7 @@ impl LegacyHashEthAddress of LegacyHash<EthAddress> {
 
 impl LegacyHashSpanFelt252 of LegacyHash<Span<felt252>> {
     fn hash(state: felt252, mut value: Span<felt252>) -> felt252 {
+        let len = value.len();
         let mut call_data_state: felt252 = 0;
         loop {
             match value.pop_front() {
@@ -24,7 +25,7 @@ impl LegacyHashSpanFelt252 of LegacyHash<Span<felt252>> {
                     call_data_state = LegacyHash::hash(call_data_state, *item);
                 },
                 Option::None(_) => {
-                    break call_data_state;
+                    break LegacyHash::hash(call_data_state, len);
                 },
             };
         }

--- a/starknet/src/utils/struct_hash.cairo
+++ b/starknet/src/utils/struct_hash.cairo
@@ -13,9 +13,7 @@ trait StructHash<T> {
 
 impl StructHashSpanFelt252 of StructHash<Span<felt252>> {
     fn struct_hash(self: @Span<felt252>) -> felt252 {
-        let mut call_data_state = LegacyHash::hash(0, *self);
-        call_data_state = LegacyHash::hash(call_data_state, (*self).len());
-        call_data_state
+        LegacyHash::hash(0, *self)
     }
 }
 


### PR DESCRIPTION
Appends length in the `LegacyHashSpanFelt252` and removes it from `StructHashSpanFelt252`, which then becomes a simple wrapper around `LegacyHashSpanFelt252`.