### PR TITLE
fix: N-02 Code Clarity Suggestions

### DIFF
--- a/starknet/src/authenticators/eth_tx.cairo
+++ b/starknet/src/authenticators/eth_tx.cairo
@@ -185,7 +185,7 @@ mod EthTxAuthenticator {
     impl InternalImpl of InternalTrait {
         fn consume_commit(ref self: ContractState, hash: felt252, sender_address: EthAddress) {
             let committer_address = self._commits.read(hash);
-            assert(!committer_address.is_zero(), 'Commit not found');
+            assert(committer_address.is_non_zero(), 'Commit not found');
             assert(committer_address == sender_address, 'Invalid sender address');
             // Delete the commit to prevent replay attacks.
             self._commits.write(hash, Zeroable::zero());

--- a/starknet/src/space/space.cairo
+++ b/starknet/src/space/space.cairo
@@ -787,7 +787,7 @@ mod Space {
             loop {
                 match _voting_strategies.pop_front() {
                     Option::Some(strategy) => {
-                        assert(!(*strategy.address).is_zero(), 'Invalid voting strategy');
+                        assert((*strategy.address).is_non_zero(), 'Invalid voting strategy');
                         cachedActiveVotingStrategies.set_bit(cachedNextVotingStrategyIndex, true);
                         self
                             ._voting_strategies

--- a/starknet/src/types/strategy.cairo
+++ b/starknet/src/types/strategy.cairo
@@ -44,10 +44,10 @@ impl StoreFelt252Array of Store<Array<felt252>> {
         // Read the stored array's length. If the length is superior to 255, the read will fail.
         let len: u8 = Store::<u8>::read_at_offset(address_domain, base, offset)
             .expect('Storage Span too large');
-        offset += 1;
+        offset += Store::<u8>::size();
 
         // Sequentially read all stored elements and append them to the array.
-        let exit = len + offset;
+        let exit = (len * Store::<felt252>::size()) + offset;
         loop {
             if offset >= exit {
                 break;
@@ -68,7 +68,7 @@ impl StoreFelt252Array of Store<Array<felt252>> {
         // // Store the length of the array in the first storage slot.
         let len: u8 = value.len().try_into().expect('Storage - Span too large');
         Store::<u8>::write_at_offset(address_domain, base, offset, len);
-        offset += 1;
+        offset += Store::<u8>::size();
 
         // Store the array elements sequentially
         loop {

--- a/starknet/src/types/strategy.cairo
+++ b/starknet/src/types/strategy.cairo
@@ -91,7 +91,7 @@ impl StoreFelt252Array of Store<Array<felt252>> {
 
     fn size() -> u8 {
         /// Since the array is a dynamic type. We use its max size here. 
-        255_u8
+        integer::BoundedU8::max()
     }
 }
 

--- a/starknet/src/utils/default.cairo
+++ b/starknet/src/utils/default.cairo
@@ -1,8 +1,8 @@
-use starknet::{ContractAddress, contract_address_const};
+use starknet::{ContractAddress, contract_address::ContractAddressZeroable};
 
 // Ideally, ContractAddress would impl Default in the corelib.
 impl ContractAddressDefault of Default<ContractAddress> {
     fn default() -> ContractAddress {
-        contract_address_const::<0>()
+        ContractAddressZeroable::zero()
     }
 }

--- a/starknet/src/utils/eip712.cairo
+++ b/starknet/src/utils/eip712.cairo
@@ -202,8 +202,7 @@ mod EIP712 {
 
         /// Adds a 16 bit prefix to a 128 bit input, returning the result and a carry.
         fn add_prefix_u128(input: u128, prefix: u128) -> (u128, u128) {
-            let with_prefix = u256 { low: input, high: 0_u128 }
-                + u256 { low: 0_u128, high: prefix };
+            let with_prefix = u256 { low: input, high: prefix };
             let carry = with_prefix & 0xffff;
             // Removing the carry and shifting back.
             let out = (with_prefix - carry) / 0x10000;

--- a/starknet/src/utils/endian.cairo
+++ b/starknet/src/utils/endian.cairo
@@ -9,10 +9,10 @@ fn uint256_into_le_u64s(self: u256) -> (u64, u64, u64, u64) {
     let high_low = integer::u128_byte_reverse(self.high & MASK_LOW) / SHIFT_64;
     let high_high = integer::u128_byte_reverse(self.high & MASK_HIGH);
     (
+        high_high.try_into().unwrap(),
+        high_low.try_into().unwrap(),
         low_high.try_into().unwrap(),
         low_low.try_into().unwrap(),
-        high_high.try_into().unwrap(),
-        high_low.try_into().unwrap()
     )
 }
 
@@ -25,7 +25,7 @@ fn into_le_u64_array(self: Array<u256>) -> (Array<u64>, u64) {
     let overflow = loop {
         match self.pop_front() {
             Option::Some(num) => {
-                let (low_high, low_low, high_high, high_low) = uint256_into_le_u64s(num);
+                let (high_high, high_low, low_high, low_low) = uint256_into_le_u64s(num);
                 if self.len() == 0 {
                     assert(low_high == 0, 'Final u256 overflows u64');
                     assert(low_low == 0, 'Final u256 overflows u64');

--- a/starknet/src/voting_strategies/merkle_whitelist.cairo
+++ b/starknet/src/voting_strategies/merkle_whitelist.cairo
@@ -4,8 +4,6 @@ mod MerkleWhitelistVotingStrategy {
     use sx::types::UserAddress;
     use sx::utils::{merkle, Leaf};
 
-    const LEAF_SIZE: usize = 4; // Serde::<Leaf>::serialize().len()
-
     #[storage]
     struct Storage {}
 
@@ -30,15 +28,10 @@ mod MerkleWhitelistVotingStrategy {
             timestamp: u32,
             voter: UserAddress,
             params: Span<felt252>, // [root: felt252]
-            user_params: Span<felt252>, // [leaf: Leaf, proof: Array<felt252>]
+            mut user_params: Span<felt252>, // [leaf: Leaf, proof: Array<felt252>]
         ) -> u256 {
-            let cache = user_params; // cache
-
-            let mut leaf_raw = cache.slice(0, LEAF_SIZE);
-            let leaf = Serde::<Leaf>::deserialize(ref leaf_raw).unwrap();
-
-            let mut proofs_raw = cache.slice(LEAF_SIZE, cache.len() - LEAF_SIZE);
-            let proofs = Serde::<Array<felt252>>::deserialize(ref proofs_raw).unwrap();
+            let (leaf, proofs) = Serde::<(Leaf, Array<felt252>)>::deserialize(ref user_params)
+                .unwrap();
 
             let root = *params.at(0); // no need to deserialize because it's a simple value
 


### PR DESCRIPTION
- Use `felt252` size and `u8` size in the read/write storage code
- Use `BoundedU8` instead of `255_u8`
- Use `ContractAddressZeroable` for `ContractAddressDefault`
- Remove useless addition of `with_prefix`
- Simplify the deserialization in `MerkleWhitelistVotingStrategy`
- Return the components in a systematic order in `uint256_into_le_u64s`
- [ ] waiting for more information regarding `Already Finalized` error message
- Use `is_non_zero()` when possible

Closes #564 