### PR TITLE
feat: move L1AvatarExecution to a Factory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16.0
+          node-version: 18.17.0
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -76,7 +76,7 @@ jobs:
             yarn-
 
       - name: Install Yarn dependencies
-        run: yarn install 
+        run: yarn install
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -89,15 +89,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Install Cairo 
-        run: curl -L https://github.com/starkware-libs/cairo/releases/download/v2.2.0/release-x86_64-unknown-linux-musl.tar.gz > cairo.tar.gz 
+      - name: Install Cairo
+        run: curl -L https://github.com/starkware-libs/cairo/releases/download/v2.2.0/release-x86_64-unknown-linux-musl.tar.gz > cairo.tar.gz
 
       - name: Extract Cairo
         run: tar -xvf cairo.tar.gz
 
-      - name: Install Scarb 
+      - name: Install Scarb
         uses: software-mansion/setup-scarb@v1
-        with: 
+        with:
           scarb-version: 0.7.0
 
       - name: Check Cairo formatting
@@ -106,7 +106,7 @@ jobs:
 
       - name: Build Cairo contracts
         working-directory: ./starknet
-        run: scarb build --verbose      
+        run: scarb build --verbose
 
       - name: Run Cairo tests
         working-directory: ./starknet
@@ -116,4 +116,4 @@ jobs:
         run: yarn hardhat starknet-build
 
       - name: run Hardhat tests
-        run:  yarn test:l1-execution; yarn test:eth-sig-auth; yarn test:stark-sig-auth;  yarn test:eth-tx-auth
+        run: yarn test:l1-execution; yarn test:eth-sig-auth; yarn test:stark-sig-auth;  yarn test:eth-tx-auth

--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -2,6 +2,6 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-solc = "0.8.19"
+solc = "0.8.20"
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/ethereum/src/execution-strategies/L1AvatarExecutionStrategy.sol
+++ b/ethereum/src/execution-strategies/L1AvatarExecutionStrategy.sol
@@ -50,13 +50,13 @@ contract L1AvatarExecutionStrategy is SimpleQuorumExecutionStrategy {
 
     /// @notice Initialization function, should be called immediately after deploying a new proxy to this contract.
     function setUp(
-            address _owner,
-            address _target,
-            address _starknetCore,
-            uint256 _executionRelayer,
-            uint256[] memory _starknetSpaces,
-            uint256 _quorum
-        ) public initializer {
+        address _owner,
+        address _target,
+        address _starknetCore,
+        uint256 _executionRelayer,
+        uint256[] memory _starknetSpaces,
+        uint256 _quorum
+    ) public initializer {
         __Ownable_init();
         transferOwnership(_owner);
         __SpaceManager_init(_starknetSpaces);

--- a/ethereum/src/execution-strategies/L1AvatarExecutionStrategy.sol
+++ b/ethereum/src/execution-strategies/L1AvatarExecutionStrategy.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 
 import "@gnosis.pm/zodiac/contracts/interfaces/IAvatar.sol";
 import "../interfaces/IStarknetCore.sol";
+import "@openzeppelin/contracts/proxy/Clones.sol";
 import {SimpleQuorumExecutionStrategy} from "./SimpleQuorumExecutionStrategy.sol";
 import "../types.sol";
 
@@ -45,37 +46,17 @@ contract L1AvatarExecutionStrategy is SimpleQuorumExecutionStrategy {
         uint256 _quorum
     );
 
-    /// @notice Constructor
-    /// @param _owner Address of the owner of this contract.
-    /// @param _target Address of the avatar that this module will pass transactions to.
-    /// @param _starknetCore Address of the StarkNet Core contract.
-    /// @param _executionRelayer Address of the StarkNet contract that will send execution details to this contract in a L2 -> L1 message
-    /// @param _starknetSpaces Array of whitelisted space contracts.
-    /// @param _quorum The quorum required to execute a proposal.
-    constructor(
-        address _owner,
-        address _target,
-        address _starknetCore,
-        uint256 _executionRelayer,
-        uint256[] memory _starknetSpaces,
-        uint256 _quorum
-    ) {
-        bytes memory initParams =
-            abi.encode(_owner, _target, _starknetCore, _executionRelayer, _starknetSpaces, _quorum);
-        setUp(initParams);
-    }
+    constructor() {}
 
     /// @notice Initialization function, should be called immediately after deploying a new proxy to this contract.
-    /// @param initParams ABI encoded parameters, in the same order as the constructor.
-    function setUp(bytes memory initParams) public initializer {
-        (
+    function setUp(
             address _owner,
             address _target,
             address _starknetCore,
             uint256 _executionRelayer,
             uint256[] memory _starknetSpaces,
             uint256 _quorum
-        ) = abi.decode(initParams, (address, address, address, uint256, uint256[], uint256));
+        ) public initializer {
         __Ownable_init();
         transferOwnership(_owner);
         __SpaceManager_init(_starknetSpaces);

--- a/ethereum/src/execution-strategies/L1AvatarExecutionStrategyFactory.sol
+++ b/ethereum/src/execution-strategies/L1AvatarExecutionStrategyFactory.sol
@@ -17,7 +17,6 @@ contract L1AvatarExecutionStrategyFactory {
         implementation = _implementation;
     }
 
-
     /// @notice Deploys a new L1 Avatar Execution Strategy contract.
     /// @param _owner Address of the owner of this contract.
     /// @param _target Address of the avatar that this module will pass transactions to.
@@ -35,7 +34,9 @@ contract L1AvatarExecutionStrategyFactory {
     ) public {
         address clone = Clones.clone(implementation);
 
-        L1AvatarExecutionStrategy(clone).setUp(_owner, _target, _starknetCore, _executionRelayer, _starknetSpaces, _quorum);
+        L1AvatarExecutionStrategy(clone).setUp(
+            _owner, _target, _starknetCore, _executionRelayer, _starknetSpaces, _quorum
+        );
         deployedContracts.push(L1AvatarExecutionStrategy(clone));
         emit ContractDeployed(clone);
     }

--- a/ethereum/src/execution-strategies/L1AvatarExecutionStrategyFactory.sol
+++ b/ethereum/src/execution-strategies/L1AvatarExecutionStrategyFactory.sol
@@ -1,0 +1,42 @@
+/// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/proxy/Clones.sol";
+import {L1AvatarExecutionStrategy} from "./L1AvatarExecutionStrategy.sol";
+
+/// @title L1 Avatar Execution Strategy Factory
+/// @notice Used to deploy new L1 Avatar Execution Strategy contracts.
+contract L1AvatarExecutionStrategyFactory {
+    address public implementation;
+    L1AvatarExecutionStrategy[] public deployedContracts;
+
+    event ContractDeployed(address indexed contractAddress);
+
+    constructor(address _implementation) {
+        implementation = _implementation;
+    }
+
+
+    /// @notice Deploys a new L1 Avatar Execution Strategy contract.
+    /// @param _owner Address of the owner of this contract.
+    /// @param _target Address of the avatar that this module will pass transactions to.
+    /// @param _starknetCore Address of the StarkNet Core contract.
+    /// @param _executionRelayer Address of the StarkNet contract that will send execution details to this contract in a L2 -> L1 message
+    /// @param _starknetSpaces Array of whitelisted space contracts.
+    /// @param _quorum The quorum required to execute a proposal.
+    function createContract(
+        address _owner,
+        address _target,
+        address _starknetCore,
+        uint256 _executionRelayer,
+        uint256[] memory _starknetSpaces,
+        uint256 _quorum
+    ) public {
+        address clone = Clones.clone(implementation);
+
+        L1AvatarExecutionStrategy(clone).setUp(_owner, _target, _starknetCore, _executionRelayer, _starknetSpaces, _quorum);
+        deployedContracts.push(L1AvatarExecutionStrategy(clone));
+        emit ContractDeployed(clone);
+    }
+}

--- a/ethereum/src/execution-strategies/L1AvatarExecutionStrategyFactory.sol
+++ b/ethereum/src/execution-strategies/L1AvatarExecutionStrategyFactory.sol
@@ -34,10 +34,11 @@ contract L1AvatarExecutionStrategyFactory {
     ) public {
         address clone = Clones.clone(implementation);
 
+        emit ContractDeployed(clone);
+
         L1AvatarExecutionStrategy(clone).setUp(
             _owner, _target, _starknetCore, _executionRelayer, _starknetSpaces, _quorum
         );
         deployedContracts.push(L1AvatarExecutionStrategy(clone));
-        emit ContractDeployed(clone);
     }
 }

--- a/ethereum/test/L1AvatarExecutionStrategy.t.sol
+++ b/ethereum/test/L1AvatarExecutionStrategy.t.sol
@@ -130,13 +130,7 @@ abstract contract L1AvatarExecutionStrategySettersTest is Test {
 
         uint256[] memory starknetSpaces = new uint256[](1);
         starknetSpaces[0] = 1;
-        avatarExecutionStrategy.setUp(
-            address(this),
-            address(this),
-            address(this),
-            0,
-            starknetSpaces,
-            0);
+        avatarExecutionStrategy.setUp(address(this), address(this), address(this), 0, starknetSpaces, 0);
     }
 
     function testEnableSpace() public {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,7 +33,7 @@ const config: HardhatUserConfig = {
         },
       },
       {
-        version: '0.8.19',
+        version: '0.8.20',
         settings: {
           optimizer: {
             enabled: true,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,6 +9,8 @@ import '@nomiclabs/hardhat-waffle';
 import '@nomiclabs/hardhat-etherscan';
 import '@nomicfoundation/hardhat-network-helpers';
 import '@nomicfoundation/hardhat-foundry';
+import '@openzeppelin/hardhat-upgrades';
+
 
 task('accounts', 'Prints the list of accounts', async (args, hre) => {
   const accounts = await hre.ethers.getSigners();

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "@types/sinon-chai": "^3.2.9",
     "@typescript-eslint/eslint-plugin": "^6.2.1",
     "@typescript-eslint/parser": "^6.2.1",
+    "@openzeppelin/contracts": "^5.0.2",
+    "@openzeppelin/hardhat-upgrades": "^3.1.0",
     "axios": "^1.5.0",
     "chai": "^4.3.7",
     "concurrently": "^7.0.0",


### PR DESCRIPTION
Edits the `L1AvatarExecutionStrategy` contract to now be spawned by the `L1AvatarExecutionStrategyFactory`, allowing for easy off-chain indexing.

Makes use of [OpenZeppelin's EIP1167 Clones implem](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/Clones.sol).

For integrators (cc @Sekhmet ) the steps to follow are now:
- Simply call [`createContract`](https://github.com/snapshot-labs/sx-starknet/blob/0fc1970c95c5d5227091cc733944d0fafe0d8f3e/ethereum/src/execution-strategies/L1AvatarExecutionStrategyFactory.sol#L27) (along with the proper arguments) on the `factory` contract (that should already be deployed by us :))
- Upon contract creation, an [event](https://github.com/snapshot-labs/sx-starknet/blob/2d3969fdd39e3832fa5704a6b9a3ddc07a07a3bf/ethereum/src/execution-strategies/L1AvatarExecutionStrategyFactory.sol#L37) will be fired for the indexer to easily track the new address. A [second event](https://github.com/snapshot-labs/sx-starknet/blob/2d3969fdd39e3832fa5704a6b9a3ddc07a07a3bf/ethereum/src/execution-strategies/L1AvatarExecutionStrategy.sol#L67) will be fired, from the newly created contract, to allow easy tracking of initial settings.

Closes #609 