### PR TITLE
remove slot is zero check in voting strategies

### DIFF
--- a/starknet/src/voting_strategies/evm_slot_value.cairo
+++ b/starknet/src/voting_strategies/evm_slot_value.cairo
@@ -56,7 +56,6 @@ mod EvmSlotValueVotingStrategy {
             let slot_value = SingleSlotProof::InternalImpl::get_storage_slot(
                 @state, timestamp, evm_contract_address, slot_key, mpt_proof
             );
-            assert(slot_value.is_non_zero(), 'Slot is zero');
 
             slot_value
         }

--- a/starknet/src/voting_strategies/oz_votes_storage_proof.cairo
+++ b/starknet/src/voting_strategies/oz_votes_storage_proof.cairo
@@ -61,7 +61,6 @@ mod OZVotesStorageProofVotingStrategy {
             let checkpoint = SingleSlotProof::InternalImpl::get_storage_slot(
                 @state, timestamp, evm_contract_address, slot_key, checkpoint_mpt_proof
             );
-            assert(checkpoint.is_non_zero(), 'Slot is zero');
 
             // Verify the checkpoint is indeed the final checkpoint by checking the next slot is zero.
             assert(

--- a/starknet/src/voting_strategies/oz_votes_trace_208_storage_proof.cairo
+++ b/starknet/src/voting_strategies/oz_votes_trace_208_storage_proof.cairo
@@ -61,7 +61,6 @@ mod OZVotesTrace208StorageProofVotingStrategy {
             let checkpoint = SingleSlotProof::InternalImpl::get_storage_slot(
                 @state, timestamp, evm_contract_address, slot_key, checkpoint_mpt_proof
             );
-            assert(checkpoint.is_non_zero(), 'Slot is zero');
 
             // Verify the checkpoint is indeed the final checkpoint by checking the next slot is zero.
             assert(


### PR DESCRIPTION
Removes `Slot is zero` check in the voting power strategies, and lets the error be at the space level rather than at the voting strategy level.