### PR TITLE
remove `verifyingContract` from stark sig

### DIFF
--- a/starknet/src/authenticators/stark_sig.cairo
+++ b/starknet/src/authenticators/stark_sig.cairo
@@ -81,7 +81,7 @@ mod StarkSigAuthenticator {
     use starknet::{ContractAddress, info};
     use sx::interfaces::{ISpaceDispatcher, ISpaceDispatcherTrait};
     use sx::types::{Strategy, IndexedStrategy, UserAddress, Choice};
-    use sx::utils::StarkEIP712;
+    use sx::utils::SNIP12;
 
     #[storage]
     struct Storage {
@@ -102,8 +102,8 @@ mod StarkSigAuthenticator {
         ) {
             assert(!self._used_salts.read((author, salt)), 'Salt Already Used');
 
-            let state = StarkEIP712::unsafe_new_contract_state();
-            StarkEIP712::InternalImpl::verify_propose_sig(
+            let state = SNIP12::unsafe_new_contract_state();
+            SNIP12::InternalImpl::verify_propose_sig(
                 @state,
                 signature,
                 space,
@@ -136,8 +136,8 @@ mod StarkSigAuthenticator {
         ) {
             // No need to check salts here, as double voting is prevented by the space itself.
 
-            let state = StarkEIP712::unsafe_new_contract_state();
-            StarkEIP712::InternalImpl::verify_vote_sig(
+            let state = SNIP12::unsafe_new_contract_state();
+            SNIP12::InternalImpl::verify_vote_sig(
                 @state,
                 signature,
                 space,
@@ -170,8 +170,8 @@ mod StarkSigAuthenticator {
         ) {
             assert(!self._used_salts.read((author, salt)), 'Salt Already Used');
 
-            let state = StarkEIP712::unsafe_new_contract_state();
-            StarkEIP712::InternalImpl::verify_update_proposal_sig(
+            let state = SNIP12::unsafe_new_contract_state();
+            SNIP12::InternalImpl::verify_update_proposal_sig(
                 @state,
                 signature,
                 space,
@@ -191,7 +191,7 @@ mod StarkSigAuthenticator {
     }
     #[constructor]
     fn constructor(ref self: ContractState, name: felt252, version: felt252) {
-        let mut state = StarkEIP712::unsafe_new_contract_state();
-        StarkEIP712::InternalImpl::initializer(ref state, name, version);
+        let mut state = SNIP12::unsafe_new_contract_state();
+        SNIP12::InternalImpl::initializer(ref state, name, version);
     }
 }

--- a/starknet/src/lib.cairo
+++ b/starknet/src/lib.cairo
@@ -39,6 +39,7 @@ mod voting_strategies {
     mod merkle_whitelist;
     use merkle_whitelist::MerkleWhitelistVotingStrategy;
 }
+
 mod proposal_validation_strategies {
     mod proposition_power;
     use proposition_power::PropositionPowerProposalValidationStrategy;
@@ -152,8 +153,8 @@ mod utils {
     mod single_slot_proof;
     use single_slot_proof::SingleSlotProof;
 
-    mod stark_eip712;
-    use stark_eip712::StarkEIP712;
+    mod snip12;
+    use snip12::SNIP12;
 
     mod struct_hash;
     use struct_hash::StructHash;

--- a/starknet/src/utils/constants.cairo
+++ b/starknet/src/utils/constants.cairo
@@ -47,7 +47,7 @@ const INDEXED_STRATEGY_TYPEHASH_LOW: u128 = 0x1d011b57ff63174d8f2b064ab6ce9cc6;
 const STARKNET_MESSAGE: felt252 = 'StarkNet Message';
 
 // StarknetKeccak('StarkNetDomain(name:felt252,version:felt252,chainId:felt252)')
-const DOMAIN_TYPEHASH: felt252 = 0x7652a980b9a4920425c858386f09477bb210dea95169abd576f5ef7c9d5ca2;
+const DOMAIN_TYPEHASH: felt252 = 0x27652a980b9a4920425c858386f09477bb210dea95169abd576f5ef7c9d5ca2;
 
 // H('Propose(space:ContractAddress,author:ContractAddress,metadataUri:felt*,executionStrategy:Strategy,
 //    userProposalValidationParams:felt*,salt:felt252)Strategy(address:felt252,params:felt*)')

--- a/starknet/src/utils/constants.cairo
+++ b/starknet/src/utils/constants.cairo
@@ -46,8 +46,8 @@ const INDEXED_STRATEGY_TYPEHASH_LOW: u128 = 0x1d011b57ff63174d8f2b064ab6ce9cc6;
 
 const STARKNET_MESSAGE: felt252 = 'StarkNet Message';
 
-// StarknetKeccak('StarkNetDomain(name:felt252,version:felt252,chainId:felt252,verifyingContract:ContractAddress)')
-const DOMAIN_TYPEHASH: felt252 = 0xa9974a36dee531bbc36aad5eeab4ade4df5ad388a296bb14d28ad4e9bf2164;
+// StarknetKeccak('StarkNetDomain(name:felt252,version:felt252,chainId:felt252)')
+const DOMAIN_TYPEHASH: felt252 = 0x7652a980b9a4920425c858386f09477bb210dea95169abd576f5ef7c9d5ca2;
 
 // H('Propose(space:ContractAddress,author:ContractAddress,metadataUri:felt*,executionStrategy:Strategy,
 //    userProposalValidationParams:felt*,salt:felt252)Strategy(address:felt252,params:felt*)')

--- a/starknet/src/utils/snip12.cairo
+++ b/starknet/src/utils/snip12.cairo
@@ -1,4 +1,4 @@
-/// EIP712 style typed data signing implementation.
+/// SNIP12 style typed data signing implementation.
 /// See here for more info: https://community.starknet.io/t/snip-off-chain-signatures-a-la-eip712/98029
 #[starknet::contract]
 mod SNIP12 {
@@ -154,7 +154,6 @@ mod SNIP12 {
             name.serialize(ref encoded_data);
             version.serialize(ref encoded_data);
             starknet::get_tx_info().unbox().chain_id.serialize(ref encoded_data);
-            starknet::get_contract_address().serialize(ref encoded_data);
             encoded_data.span().struct_hash()
         }
 

--- a/starknet/src/utils/snip12.cairo
+++ b/starknet/src/utils/snip12.cairo
@@ -1,7 +1,7 @@
 /// EIP712 style typed data signing implementation.
 /// See here for more info: https://community.starknet.io/t/snip-off-chain-signatures-a-la-eip712/98029
 #[starknet::contract]
-mod StarkEIP712 {
+mod SNIP12 {
     use starknet::ContractAddress;
     use openzeppelin::account::interface::{AccountABIDispatcher, AccountABIDispatcherTrait};
     use sx::types::{Strategy, IndexedStrategy, Choice};

--- a/tests/stark-sig-auth.test.ts
+++ b/tests/stark-sig-auth.test.ts
@@ -101,7 +101,6 @@ describe('Starknet Signature Authenticator', function () {
       name: 'sx-sn',
       version: '0.1.0',
       chainId: '0x534e5f474f45524c49', // devnet id
-      verifyingContract: starkSigAuthenticator.address,
     };
 
     // Dumping the Starknet state so it can be loaded at the same point for each test

--- a/tests/stark-sig-types.ts
+++ b/tests/stark-sig-types.ts
@@ -3,7 +3,6 @@ export const domainTypes = {
     { name: 'name', type: 'felt252' },
     { name: 'version', type: 'felt252' },
     { name: 'chainId', type: 'felt252' },
-    { name: 'verifyingContract', type: 'ContractAddress' },
   ],
 };
 


### PR DESCRIPTION
Removes the `verifyingContract` from the `stark-sig` authenticator. This is done because [SNIP12](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md) does not support the `verifyingContract` key.
We also rename `StarkEIP712` to `SNIP12` for clarity.

The only important changes in this PR are:
1. Removing the `verifyingContract` from and updating the domain hash: https://github.com/snapshot-labs/sx-starknet/blob/4e8ebcec63bb8b6319f927b561c547eacaee6892/starknet/src/utils/constants.cairo#L49-L50 (check git blame)
2. Removing the contract_address from the `get_domain_hash` function (was previously here, you can check git blame: https://github.com/snapshot-labs/sx-starknet/blob/4e8ebcec63bb8b6319f927b561c547eacaee6892/starknet/src/utils/snip12.cairo#L157)

The remaining are `StarkEIP712 -> SNIP12`. I realize now it would've been cleaner with only two distinct commits.