### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ yarn test-ts
 
 #### Run Hardhat Tests
 
-The Hardhat tests can be run following the procedure followed in the [CI](.github/workflows/test.yml). You will need local Starknet Devnet and Ethereum devnet instances running. 
+The Hardhat tests can be run following the procedure in the [CI](.github/workflows/test.yml). You will need local Starknet Devnet and Ethereum devnet instances running. 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
The word `followed` is redundant here. It would be better to use the construction: `following the procedure in the CI`

Please review the changes and let me know if any additional changes are needed.